### PR TITLE
updates to handle randomized parameters samples

### DIFF
--- a/MFVNeutralino/plugins/EventFilter.cc
+++ b/MFVNeutralino/plugins/EventFilter.cc
@@ -72,6 +72,7 @@ bool MFVEventFilter::filter(edm::Event& event, const edm::EventSetup&) {
   const edm::LuminosityBlock& lumi = event.getLuminosityBlock();
 
   // If pertinent, parse randpar configuration
+  // the randpar filter WILL supersede the base eventFilter. Thus, only one filter is allowed to be applied 
   if (parse_randpars) {
     
     edm::Handle<GenLumiInfoHeader> gen_header;
@@ -82,7 +83,9 @@ bool MFVEventFilter::filter(edm::Event& event, const edm::EventSetup&) {
     std::string str_ctau = "ctauS-" + randpar_ctau;
     std::string str_dcay = randpar_dcay;
     std::string comp_string_Zn = "ZH_" + str_dcay + "_ZToLL_MH-125_" + str_mass + "_" + str_ctau + "_TuneCP5_13TeV-powheg-pythia8";
-    std::string comp_string_Wp = "WplusH_" + str_dcay + "_WToLNu_MH-125_" + str_mass + "_" + str_ctau + "_TuneCP5_13TeV-powheg-pythia8";std::string comp_string_Wm = "WminusH_" + str_dcay + "_WToLNu_MH-125_" + str_mass + "_" + str_ctau + "_TuneCP5_13TeV-powheg-pythia8";
+    std::string comp_string_Wp = "WplusH_" + str_dcay + "_WToLNu_MH-125_" + str_mass + "_" + str_ctau + "_TuneCP5_13TeV-powheg-pythia8";
+    std::string comp_string_Wm = "WminusH_" + str_dcay + "_WToLNu_MH-125_" + str_mass + "_" + str_ctau + "_TuneCP5_13TeV-powheg-pythia8";
+    
     if (not ((comp_string_Wp == rp_config_desc) or (comp_string_Zn == rp_config_desc) or (comp_string_Wm == rp_config_desc))) {
       return false;
     }

--- a/MFVNeutralino/plugins/EventFilter.cc
+++ b/MFVNeutralino/plugins/EventFilter.cc
@@ -82,8 +82,8 @@ bool MFVEventFilter::filter(edm::Event& event, const edm::EventSetup&) {
     std::string str_ctau = "ctauS-" + randpar_ctau;
     std::string str_dcay = randpar_dcay;
     std::string comp_string_Zn = "ZH_" + str_dcay + "_ZToLL_MH-125_" + str_mass + "_" + str_ctau + "_TuneCP5_13TeV-powheg-pythia8";
-    std::string comp_string_Wp = "WplusH_HToSSTodddd_WToLNu_MH-125_" + str_mass + "_" + str_ctau + "_TuneCP5_13TeV-powheg-pythia8";
-    if (not ((comp_string_Wp == rp_config_desc) or (comp_string_Zn == rp_config_desc))) {
+    std::string comp_string_Wp = "WplusH_" + str_dcay + "_WToLNu_MH-125_" + str_mass + "_" + str_ctau + "_TuneCP5_13TeV-powheg-pythia8";std::string comp_string_Wm = "WminusH_" + str_dcay + "_WToLNu_MH-125_" + str_mass + "_" + str_ctau + "_TuneCP5_13TeV-powheg-pythia8";
+    if (not ((comp_string_Wp == rp_config_desc) or (comp_string_Zn == rp_config_desc) or (comp_string_Wm == rp_config_desc))) {
       return false;
     }
     else {

--- a/MFVNeutralino/python/EventFilter.py
+++ b/MFVNeutralino/python/EventFilter.py
@@ -110,7 +110,8 @@ def setup_event_filter(process,
         elif event_filter == 'bjets OR displaced dijet veto HT':
             from JMTucker.MFVNeutralino.EventFilter_cfi import mfvEventFilterBjetsORDisplacedDijetVetoHT as eventFilter
 
-        #currently either rp_filter is on OR event_filter is on; cannot have both
+        # for rp filter to be correctly applied, must have event_filter to TRUE;
+        # currently cannot have both rp_filter AND event filter 
         elif event_filter is True:
             if rp_filter:
                 from JMTucker.MFVNeutralino.EventFilter_cfi import mfvEventFilterRandomParameters as eventFilter

--- a/MFVNeutralino/python/EventFilter_cfi.py
+++ b/MFVNeutralino/python/EventFilter_cfi.py
@@ -15,6 +15,10 @@ mfvEventFilter = cms.EDFilter('MFVEventFilter',
                               electron_cut = jtupleParams.electronCut,
                               min_electron_pt = cms.double(35),
                               min_nleptons = cms.int32(1),
+                              parse_randpars = cms.bool(False), 
+                              randpar_mass = cms.int32(-1),
+                              randpar_ctau = cms.string(''),
+                              randpar_dcay = cms.string(''),
                               debug = cms.untracked.bool(False),
                               )
 
@@ -22,3 +26,5 @@ mfvEventFilterJetsOnly = mfvEventFilter.clone(mode = 'jets only')
 mfvEventFilterLeptonsOnly = mfvEventFilter.clone(mode = 'leptons only')
 mfvEventFilterHTORBjetsORDisplacedDijet = mfvEventFilter.clone(mode = 'HT OR bjets OR displaced dijet', min_ht = cms.double(-1))
 mfvEventFilterBjetsORDisplacedDijetVetoHT = mfvEventFilter.clone(mode = 'bjets OR displaced dijet veto HT', min_ht = cms.double(-1))
+mfvEventFilterRandomParameters = mfvEventFilter.clone(min_pt_for_ht = cms.double(-1), min_ht = cms.double(-1), min_njets = cms.int32(0),
+                                                      min_electron_pt = cms.double(-1), min_muon_pt = cms.double(-1), min_nleptons = cms.int32(0))

--- a/MFVNeutralino/python/NtupleCommon.py
+++ b/MFVNeutralino/python/NtupleCommon.py
@@ -311,16 +311,16 @@ def signal_uses_random_pars_modifier(sample):
     to_replace = []
 
     if sample.is_signal:
-        if sample.name.startswith('ZH_') or sample.name.startswith('Wplus'):
+        if sample.is_rp :
             magic_randpar = 'randpars_filter = False'
-            
-            decay = sample.name[sample.name.find('_')+1 : sample.name.find('_Z')]
-            
-            if sample.tau < 1000 :
-                ctau = float(sample.tau)/1000
+            decay = sample.name.split('_')[1]
+
+            ctau = float(sample.tau)/1000
+            if ctau < 1 :
                 ctau = str(ctau).replace('.', 'p')
             else :
-                ctau = str(sample.tau/1000)
+                ctau = str(ctau).replace('.', 'p')
+                ctau = ctau.replace('p0', '')
                 
             to_replace.append((magic_randpar, "randpars_filter = 'randpar %s M%i_ct%s-'" % (decay, sample.mass, ctau), 'tuple template does not contain the magic string "%s"' % magic_randpar))
     return [], to_replace

--- a/MFVNeutralino/python/NtupleCommon.py
+++ b/MFVNeutralino/python/NtupleCommon.py
@@ -305,7 +305,7 @@ def ntuple_process(settings):
     else:
         return aod_ntuple_process(settings)
 
-# Used for samples stored in inclusive miniaods; currently set up for ZH and Wplus
+# Used for samples stored in inclusive miniaods; currently set up for ZH, Wplus & Wminus
 # may need to change to handle different naming conventions 
 def signal_uses_random_pars_modifier(sample): 
     to_replace = []
@@ -315,6 +315,9 @@ def signal_uses_random_pars_modifier(sample):
             magic_randpar = 'randpars_filter = False'
             decay = sample.name.split('_')[1]
 
+            # need some nuance with formatting ctau from float -> string to correctly match to the comparison string
+            # if ctau < 1 : e.g. want 0p1, 0p05 mm
+            # if ctau > 1 : e.g. want 10, 30 mm
             ctau = float(sample.tau)/1000
             if ctau < 1 :
                 ctau = str(ctau).replace('.', 'p')

--- a/MFVNeutralino/test/README
+++ b/MFVNeutralino/test/README
@@ -1,0 +1,85 @@
+This is the README for : running over different scripts in the framework 
+     Additionally the random parameter scheme (rp) is described in detail
+
+
+####################################################################################################################################################
+
+ntuple.py
+
+-- Creation of tuples with vertexing and event information
+-- the settings are declared in python/NtupleCommon.py
+
+-> run locally :             $ cmsRun ntuple.py
+-> submit over condor/crab : $ python ntuple.py submit
+-> to monitor condor jobs :  $ condor_q
+-> after jobs finish :       $ mpublish --partial --dataset <NtupleVersion> /path/to/ntuples |& tee log_mpublish_<NtupleVersion>
+
+         
+	 A) EVENT FILTER : During this stage, no event filter is applied. This is done via the signals_no_event_filter_modifier.
+	 For this to work when running jobs over condor/crab, settings.event_filter should be defined as either : 'jets only', 'leptons only' etc.
+	 The pset modifier will then search for this string and replace it with 'False'.
+
+
+	 B) RANDOM PARAMETER FILTER (RP) : If the sample was centrally produced using a random parameter scheme in which all configuration points
+	 (mass, lifetime) are grouped into one inclusive file, this filter MUST be applied. To apply this filter when running jobs over condor/crab,
+	 settings.randpars_filter should be defined as : 'False'. Then, the pset modifer will correctly replace it with the following syntax :
+	 'randpar <decay> M<mass>_ct<lifetime>-'
+
+	 e.g.
+	 randpar HToSSTodddd M07_ct0p05-
+	 randpar HToSSTobbbb M55_ct10-
+
+	 -- To do a local test run before submission while keeping the randpars_filter, settings.randpars_filter should be defined as
+   	 'randpar <decay> M<mass>_ct<lifetime>-', as described above
+
+
+	 --> Note: You cannot have BOTH the event filter AND the rp filter applied. If you do, the event filter will be overwritten with the rp filter
+	     [as of the construction of this README] 
+
+
+####################################################################################################################################################
+
+minitree.py
+
+-- Slim Tuples down to Minitrees (input is ntuples created in above step) 
+-- different minitrees are defined in python/MiniTree_cff.py
+-- Output can be used for signal_eff.py (trigger + preselection + vertex selection efficiency) 
+
+-> run locally :             $ cmsRun minitree.py
+-> submit over condor/crab : $ python minitree.py submit
+-> after jobs finish :       $ mhadd /path/to/crabdirs/directory/<MiniTreeVersion> --ignore-done 
+
+
+####################################################################################################################################################
+
+histos.py
+
+-- More distributions of vertex and event information (input is ntuples created in above step) 
+-- Can make different subdirectories with different cuts (e.g. ntracks, nm1)
+-- Output can be used for comparehists.py
+
+
+-> run locally :             $ cmsRun histos.py
+-> submit over condor/crab : $ python histos.py submit
+-> after jobs finish :       $ mhadd /path/to/crabdirs/directory/<HistosVersion> --ignore-done
+
+
+####################################################################################################################################################
+
+Trigger Studies :
+
+filtercheck.py
+
+--Saves two distributions : 1. number of triggers  2. number of triggers that pass in an event
+--output to be used to run over TriggerStudies/signal_eff.py (just trigger efficiency)
+
+-> run locally :             $ cmsRun filtercheck.py
+-> submit over condor/crab : $ python filtercheck.py submit
+-> after jobs finish :       $ mhadd /path/to/crabdirs/directory/<TrigFiltCHeckVersion> --ignore-done
+
+
+
+   When using the RP scheme, the random parameter filter needs to be applied in this step to obtain the correct trigger efficiency.
+   The same syntax for rp filter as ntuple.py is used here when submitting jobs to condor or running locally.
+
+

--- a/MFVNeutralino/test/TriggerStudies/filtercheck.py
+++ b/MFVNeutralino/test/TriggerStudies/filtercheck.py
@@ -7,9 +7,11 @@ settings.is_mc = True
 settings.is_miniaod = True
 settings.cross = '' # 2017to2018' # 2017to2017p8'
 
-randpars_filter = False
-#randpars_filter = 'randpar HToSSTobbbb M15_ct10-'
 #for submission to condor
+randpars_filter = False
+#for testing local :
+#randpars_filter = 'randpar HToSSTobbbb M15_ct10-'
+
 
 sample_files(process, 'qcdht1000_2017', 'miniaod')
 geometry_etc(process, settings)

--- a/MFVNeutralino/test/TriggerStudies/filtercheck.py
+++ b/MFVNeutralino/test/TriggerStudies/filtercheck.py
@@ -1,10 +1,15 @@
 import sys
 from JMTucker.Tools.BasicAnalyzer_cfg import *
+from JMTucker.MFVNeutralino.NtupleCommon import signal_uses_random_pars_modifier
 
 settings = CMSSWSettings()
 settings.is_mc = True
 settings.is_miniaod = True
 settings.cross = '' # 2017to2018' # 2017to2017p8'
+
+randpars_filter = False
+#randpars_filter = 'randpar HToSSTobbbb M15_ct10-'
+#for submission to condor
 
 sample_files(process, 'qcdht1000_2017', 'miniaod')
 geometry_etc(process, settings)
@@ -12,7 +17,7 @@ tfileservice(process, 'filtercheck.root')
 cmssw_from_argv(process)
 
 from JMTucker.MFVNeutralino.EventFilter import setup_event_filter
-sef = lambda *a,**kwa: setup_event_filter(process, *a, input_is_miniaod=True, **kwa)
+sef = lambda *a,**kwa: setup_event_filter(process, *a, input_is_miniaod=True, rp_mode = randpars_filter, **kwa)
 sef('pTrigger', mode = 'trigger jets only')
 sef('pTriggerBjets', mode = 'trigger bjets only',name_ex = 'bjets')
 sef('pTriggerDispDijet', mode = 'trigger displaced dijet only',name_ex = 'displaced_dijet')
@@ -28,7 +33,7 @@ if len(process.mfvTriggerFilter.HLTPaths) > 1:
         getattr(process, filt_name).HLTPaths = [x]
 
 import JMTucker.Tools.SimpleTriggerEfficiency_cfi as SimpleTriggerEfficiency
-SimpleTriggerEfficiency.setup_endpath(process)
+SimpleTriggerEfficiency.setup_endpath(process, randpars_filter)
 
 
 if __name__ == '__main__' and hasattr(sys, 'argv') and 'submit' in sys.argv:
@@ -44,5 +49,5 @@ if __name__ == '__main__' and hasattr(sys, 'argv') and 'submit' in sys.argv:
         #samples = Samples.all_signal_samples_2018
 
     ms = MetaSubmitter('TrigFiltCheckV1', dataset='miniaod')
-    ms.common.pset_modifier = chain_modifiers(is_mc_modifier, era_modifier, npu_filter_modifier(settings.is_miniaod), per_sample_pileup_weights_modifier(cross=settings.cross))
+    ms.common.pset_modifier = chain_modifiers(is_mc_modifier, era_modifier, npu_filter_modifier(settings.is_miniaod), per_sample_pileup_weights_modifier(cross=settings.cross), signal_uses_random_pars_modifier)
     ms.submit(samples)

--- a/MFVNeutralino/test/ntuple.py
+++ b/MFVNeutralino/test/ntuple.py
@@ -16,6 +16,7 @@ if use_btag_triggers :
 else :
     settings.event_filter = 'jets only'
 
+# see readme for randpars
 settings.randpars_filter = False
 # if want to test local : 
 #settings.randpars_filter = 'randpar HToSSTodddd M07_ct0p05-'

--- a/MFVNeutralino/test/ntuple.py
+++ b/MFVNeutralino/test/ntuple.py
@@ -16,9 +16,13 @@ if use_btag_triggers :
 else :
     settings.event_filter = 'jets only'
 
+settings.randpars_filter = False
+# if want to test local : 
+#settings.randpars_filter = 'randpar HToSSTobbbb M15_ct10-'
+
 process = ntuple_process(settings)
 dataset = 'miniaod' if settings.is_miniaod else 'main'
-sample_files(process, 'mfv_neu_tau001000um_M1200_2017', dataset, 1)
+sample_files(process, 'mfv_neu_tau001000um_M1200_2018', dataset, 1)
 max_events(process, 1000)
 cmssw_from_argv(process)
 
@@ -34,6 +38,6 @@ if __name__ == '__main__' and hasattr(sys, 'argv') and 'submit' in sys.argv:
     set_splitting(samples, dataset, 'ntuple', data_json=json_path('ana_2017p8.json'), limit_ttbar=True)
 
     ms = MetaSubmitter(settings.batch_name(), dataset=dataset)
-    ms.common.pset_modifier = chain_modifiers(is_mc_modifier, era_modifier, npu_filter_modifier(settings.is_miniaod), signals_no_event_filter_modifier)
+    ms.common.pset_modifier = chain_modifiers(is_mc_modifier, era_modifier, npu_filter_modifier(settings.is_miniaod), signals_no_event_filter_modifier, signal_uses_random_pars_modifier)
     ms.condor.stageout_files = 'all'
     ms.submit(samples)

--- a/MFVNeutralino/test/ntuple.py
+++ b/MFVNeutralino/test/ntuple.py
@@ -18,11 +18,13 @@ else :
 
 settings.randpars_filter = False
 # if want to test local : 
-#settings.randpars_filter = 'randpar HToSSTobbbb M15_ct10-'
+#settings.randpars_filter = 'randpar HToSSTodddd M07_ct0p05-'
+
 
 process = ntuple_process(settings)
 dataset = 'miniaod' if settings.is_miniaod else 'main'
 sample_files(process, 'mfv_neu_tau001000um_M1200_2018', dataset, 1)
+
 max_events(process, 1000)
 cmssw_from_argv(process)
 
@@ -34,7 +36,7 @@ if __name__ == '__main__' and hasattr(sys, 'argv') and 'submit' in sys.argv:
         samples = pick_samples(dataset, qcd=True, ttbar=False, all_signal=not settings.run_n_tk_seeds, data=False, bjet=True) # no data currently; no sliced ttbar since inclusive is used
     else :
         samples = pick_samples(dataset, qcd=False, ttbar=False, data=False, all_signal=not settings.run_n_tk_seeds)
-
+        
     set_splitting(samples, dataset, 'ntuple', data_json=json_path('ana_2017p8.json'), limit_ttbar=True)
 
     ms = MetaSubmitter(settings.batch_name(), dataset=dataset)

--- a/Tools/interface/Year.h
+++ b/Tools/interface/Year.h
@@ -1,7 +1,7 @@
 #ifndef JMTucker_Tools_interface_Year_h
 #define JMTucker_Tools_interface_Year_h
 
-#define MFVNEUTRALINO_2017
+#define MFVNEUTRALINO_2018
 
 #define MFVNEUTRALINO_YEARS {2017, 2018}
 

--- a/Tools/interface/Year.h
+++ b/Tools/interface/Year.h
@@ -1,7 +1,7 @@
 #ifndef JMTucker_Tools_interface_Year_h
 #define JMTucker_Tools_interface_Year_h
 
-#define MFVNEUTRALINO_2018
+#define MFVNEUTRALINO_2017
 
 #define MFVNEUTRALINO_YEARS {2017, 2018}
 

--- a/Tools/plugins/SimpleTriggerEfficiency.cc
+++ b/Tools/plugins/SimpleTriggerEfficiency.cc
@@ -149,8 +149,9 @@ void SimpleTriggerEfficiency::analyze(const edm::Event& event, const edm::EventS
     std::string str_ctau = "ctauS-" + randpar_ctau;
     std::string str_dcay = randpar_dcay;
     std::string comp_string_Zn = "ZH_" + str_dcay + "_ZToLL_MH-125_" + str_mass + "_" + str_ctau + "_TuneCP5_13TeV-powheg-pythia8";
-    std::string comp_string_Wp = "WplusH_HToSSTodddd_WToLNu_MH-125_" + str_mass + "_" + str_ctau + "_TuneCP5_13TeV-powheg-pythia8";
-    if (( comp_string_Wp == rp_config_desc) or (comp_string_Zn == rp_config_desc)) {
+    std::string comp_string_Wp = "WplusH_" + str_dcay + "_WToLNu_MH-125_" + str_mass + "_" + str_ctau + "_TuneCP5_13TeV-powheg-pythia8";
+    std::string comp_string_Wm = "WminusH_" + str_dcay + "_WToLNu_MH-125_" + str_mass + "_" + str_ctau + "_TuneCP5_13TeV-powheg-pythia8";
+    if (( comp_string_Wp == rp_config_desc) or (comp_string_Zn == rp_config_desc) or (comp_string_Wm == rp_config_desc)) {
     
   
       for (size_t ipath = 0; ipath < npaths; ++ipath)

--- a/Tools/plugins/SimpleTriggerEfficiency.cc
+++ b/Tools/plugins/SimpleTriggerEfficiency.cc
@@ -10,6 +10,8 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 
 class SimpleTriggerEfficiency : public edm::EDAnalyzer {
 public:
@@ -19,8 +21,13 @@ private:
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
   const edm::EDGetTokenT<edm::TriggerResults> trigger_results_token;
+  const edm::EDGetTokenT<GenLumiInfoHeader> gen_lumi_header_token; // for randpar parsing 
   const edm::EDGetTokenT<double> weight_token;
   const bool use_weight;
+  const bool parse_randpars;
+  const int randpar_mass;
+  const std::string(randpar_ctau);
+  const std::string(randpar_dcay);
   std::map<std::string, unsigned> prescales;
 
   bool pass_prescale(std::string path, double rand) const;
@@ -33,8 +40,13 @@ private:
 
 SimpleTriggerEfficiency::SimpleTriggerEfficiency(const edm::ParameterSet& cfg) 
   : trigger_results_token(consumes<edm::TriggerResults>(cfg.getParameter<edm::InputTag>("trigger_results_src"))),
+    gen_lumi_header_token(consumes<GenLumiInfoHeader, edm::InLumi>(edm::InputTag("generator"))),
     weight_token(consumes<double>(cfg.getParameter<edm::InputTag>("weight_src"))),
     use_weight(cfg.getParameter<edm::InputTag>("weight_src").label() != ""),
+    parse_randpars(cfg.getParameter<bool>("parse_randpars")),
+    randpar_mass(cfg.getParameter<int>("randpar_mass")),
+    randpar_ctau(cfg.getParameter<std::string>("randpar_ctau")),
+    randpar_dcay(cfg.getParameter<std::string>("randpar_dcay")),
     triggers_pass_num(0),
     triggers_pass_den(0),
     triggers2d_pass_num(0),
@@ -78,6 +90,9 @@ void SimpleTriggerEfficiency::analyze(const edm::Event& event, const edm::EventS
   event.getByToken(trigger_results_token, trigger_results);
   const edm::TriggerNames& trigger_names = event.triggerNames(*trigger_results);
   const size_t npaths = trigger_names.size();
+  const edm::LuminosityBlock& lumi = event.getLuminosityBlock();
+  edm::Handle<GenLumiInfoHeader> gen_header;
+  lumi.getByToken(gen_lumi_header_token, gen_header);
 
   if (triggers_pass_num == 0) {
     // Initialize the histograms now that we have the information on
@@ -126,21 +141,52 @@ void SimpleTriggerEfficiency::analyze(const edm::Event& event, const edm::EventS
   CLHEP::HepRandomEngine& rng_engine = rng->getEngine(event.streamID());
 
   std::vector<bool> acc(npaths, false);
-  
-  for (size_t ipath = 0; ipath < npaths; ++ipath)
-    acc[ipath] = trigger_results->accept(ipath) && pass_prescale(trigger_names.triggerName(ipath), rng_engine.flat());
-  
-  for (size_t ipath = 0; ipath < npaths; ++ipath) {
-    triggers_pass_den->Fill(ipath, weight);
-    const bool iacc = acc[ipath];
-    if (iacc)
-      triggers_pass_num->Fill(ipath, weight);
 
-    for (size_t jpath = 0; jpath < ipath; ++jpath) {
-      triggers2d_pass_den->Fill(ipath, jpath, weight);
-      const bool jacc = acc[jpath];
-      if (iacc || jacc)
-	triggers2d_pass_num->Fill(ipath, jpath, weight);
+  // filling histos depends on if the sample is rp or not  
+  if (parse_randpars) {
+    std::string rp_config_desc = gen_header->configDescription();
+    std::string str_mass = "MS-" + std::to_string(randpar_mass);
+    std::string str_ctau = "ctauS-" + randpar_ctau;
+    std::string str_dcay = randpar_dcay;
+    std::string comp_string_Zn = "ZH_" + str_dcay + "_ZToLL_MH-125_" + str_mass + "_" + str_ctau + "_TuneCP5_13TeV-powheg-pythia8";
+    std::string comp_string_Wp = "WplusH_HToSSTodddd_WToLNu_MH-125_" + str_mass + "_" + str_ctau + "_TuneCP5_13TeV-powheg-pythia8";
+    if (( comp_string_Wp == rp_config_desc) or (comp_string_Zn == rp_config_desc)) {
+    
+  
+      for (size_t ipath = 0; ipath < npaths; ++ipath)
+	acc[ipath] = trigger_results->accept(ipath) && pass_prescale(trigger_names.triggerName(ipath), rng_engine.flat());
+  
+      for (size_t ipath = 0; ipath < npaths; ++ipath) {
+	triggers_pass_den->Fill(ipath, weight);
+	const bool iacc = acc[ipath];
+	if (iacc)
+	  triggers_pass_num->Fill(ipath, weight);
+    
+	for (size_t jpath = 0; jpath < ipath; ++jpath) {
+	  triggers2d_pass_den->Fill(ipath, jpath, weight);
+	  const bool jacc = acc[jpath];
+	  if (iacc || jacc)
+	    triggers2d_pass_num->Fill(ipath, jpath, weight);
+	}
+      }
+    }
+  }
+  else {
+    for (size_t ipath = 0; ipath < npaths; ++ipath)
+      acc[ipath] = trigger_results->accept(ipath) && pass_prescale(trigger_names.triggerName(ipath), rng_engine.flat());
+  
+    for (size_t ipath = 0; ipath < npaths; ++ipath) {
+      triggers_pass_den->Fill(ipath, weight);
+      const bool iacc = acc[ipath];
+      if (iacc)
+	triggers_pass_num->Fill(ipath, weight);
+      
+      for (size_t jpath = 0; jpath < ipath; ++jpath) {
+	triggers2d_pass_den->Fill(ipath, jpath, weight);
+	const bool jacc = acc[jpath];
+	if (iacc || jacc)
+	  triggers2d_pass_num->Fill(ipath, jpath, weight);
+      }
     }
   }
 }

--- a/Tools/python/MetaSubmitter.py
+++ b/Tools/python/MetaSubmitter.py
@@ -223,6 +223,7 @@ def set_splitting(samples, dataset, jobtype='default', data_json=None, default_f
         # Shed/presel_splitting.py
         d = {'miniaod': {
                 'signal':           ( 1,     200),
+                'rp_signal':        ( 1,    3000),
                 'JetHT':            (15, 1350000),
                 'qcdht0300_2017':   (50, 3130000),
                 'qcdht0500_2017':   (50, 3130000),
@@ -258,8 +259,12 @@ def set_splitting(samples, dataset, jobtype='default', data_json=None, default_f
             if 'JetHT' in name:
                 name = 'JetHT'
             elif sample.is_signal:
-                name = 'signal'
-                sample.split_by = 'events'
+                if sample.is_rp :
+                    name = 'rp_signal'
+                    sample.split_by = 'events'
+                else :
+                    name = 'signal'
+                    sample.split_by = 'events'
 
             sample.files_per, sample.events_per = d[dataset].get(name, (50, 100000))
 

--- a/Tools/python/Samples.py
+++ b/Tools/python/Samples.py
@@ -48,6 +48,9 @@ def _decay(sample):
         'mfv_stopbbarbbar': r'\tilde{t} \rightarrow \bar{b}\bar{b}',
         'ggHToSSTobbbb' : r'ggH \rightarrow SS \rightarrow b\bar{b}b\bar{b}',
         'ggHToSSTodddd' : r'ggH \rightarrow SS \rightarrow d\bar{d}d\bar{d}',
+        'ZH_HToSSTodddd_ZToll' : r'ZH \rightarrow SS \rightarrow d\bar{d}d\bar{d}, Z \rightarrow ll', 
+        'ZH_HToSSTobbbb_ZToll' : r'ZH \rightarrow SS \rightarrow b\bar{b}b\bar{b}, Z \rightarrow ll', 
+        'ZH_HToSSTo4Tau_ZToll' : r'ZH \rightarrow SS \rightarrow \tau\tau\tau\tau, Z \rightarrow ll', 
         }[_model(s)]
     year = int(s.rsplit('_')[-1])
     assert 2015 <= year <= 2018
@@ -239,7 +242,42 @@ HToSSTodddd_samples_2017 = [
     MCSample('ggHToSSTodddd_tau1mm_M55_2017',    '/ggH_HToSSTodddd_MH-125_MS-55_ctauS-1_pT75_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_mc2017_realistic_v14-v1/MINIAODSIM', 186554),
 ]
 
-all_signal_samples_2017 = mfv_signal_samples_2017 + mfv_stopdbardbar_samples_2017 + HToSSTobbbb_samples_2017 + HToSSTodddd_samples_2017
+ZH_HToSSTobbbb_ZToLL_samples_2017 = [
+    MCSample('ZH_HToSSTobbbb_ZToll_tau000050um_M15_2017', '/ZH_HToSSTobbbb_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1136101),
+    MCSample('ZH_HToSSTobbbb_ZToll_tau001000um_M15_2017', '/ZH_HToSSTobbbb_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1136101),
+    MCSample('ZH_HToSSTobbbb_ZToll_tau010000um_M15_2017', '/ZH_HToSSTobbbb_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1136101),
+    MCSample('ZH_HToSSTobbbb_ZToll_tau100000um_M15_2017', '/ZH_HToSSTobbbb_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1136101),
+    MCSample('ZH_HToSSTobbbb_ZToll_tau000050um_M40_2017', '/ZH_HToSSTobbbb_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1136101),
+    MCSample('ZH_HToSSTobbbb_ZToll_tau001000um_M40_2017', '/ZH_HToSSTobbbb_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1136101),
+    MCSample('ZH_HToSSTobbbb_ZToll_tau010000um_M40_2017', '/ZH_HToSSTobbbb_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1136101),
+    MCSample('ZH_HToSSTobbbb_ZToll_tau100000um_M40_2017', '/ZH_HToSSTobbbb_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1136101),
+    MCSample('ZH_HToSSTobbbb_ZToll_tau000050um_M55_2017', '/ZH_HToSSTobbbb_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1136101),
+    MCSample('ZH_HToSSTobbbb_ZToll_tau001000um_M55_2017', '/ZH_HToSSTobbbb_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1136101),
+    MCSample('ZH_HToSSTobbbb_ZToll_tau010000um_M55_2017', '/ZH_HToSSTobbbb_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1136101),
+    MCSample('ZH_HToSSTobbbb_ZToll_tau100000um_M55_2017', '/ZH_HToSSTobbbb_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1136101),
+]
+
+
+ZH_HToSSTodddd_ZToLL_samples_2017 = [
+    MCSample('ZH_HToSSTodddd_ZToll_tau000050um_M07_2017', '/ZH_HToSSTodddd_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1548790),
+    MCSample('ZH_HToSSTodddd_ZToll_tau001000um_M07_2017', '/ZH_HToSSTodddd_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1548790),
+    MCSample('ZH_HToSSTodddd_ZToll_tau010000um_M07_2017', '/ZH_HToSSTodddd_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1548790),
+    MCSample('ZH_HToSSTodddd_ZToll_tau100000um_M07_2017', '/ZH_HToSSTodddd_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1548790),
+    MCSample('ZH_HToSSTodddd_ZToll_tau000050um_M15_2017', '/ZH_HToSSTodddd_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1548790),
+    MCSample('ZH_HToSSTodddd_ZToll_tau001000um_M15_2017', '/ZH_HToSSTodddd_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1548790),
+    MCSample('ZH_HToSSTodddd_ZToll_tau010000um_M15_2017', '/ZH_HToSSTodddd_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1548790),
+    MCSample('ZH_HToSSTodddd_ZToll_tau100000um_M15_2017', '/ZH_HToSSTodddd_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1548790),
+    MCSample('ZH_HToSSTodddd_ZToll_tau000050um_M40_2017', '/ZH_HToSSTodddd_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1548790),
+    MCSample('ZH_HToSSTodddd_ZToll_tau001000um_M40_2017', '/ZH_HToSSTodddd_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1548790),
+    MCSample('ZH_HToSSTodddd_ZToll_tau010000um_M40_2017', '/ZH_HToSSTodddd_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1548790),
+    MCSample('ZH_HToSSTodddd_ZToll_tau100000um_M40_2017', '/ZH_HToSSTodddd_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1548790),
+    MCSample('ZH_HToSSTodddd_ZToll_tau000050um_M55_2017', '/ZH_HToSSTodddd_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1548790),
+    MCSample('ZH_HToSSTodddd_ZToll_tau001000um_M55_2017', '/ZH_HToSSTodddd_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1548790),
+    MCSample('ZH_HToSSTodddd_ZToll_tau010000um_M55_2017', '/ZH_HToSSTodddd_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1548790),
+    MCSample('ZH_HToSSTodddd_ZToll_tau100000um_M55_2017', '/ZH_HToSSTodddd_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1548790),
+]
+
+all_signal_samples_2017 = mfv_signal_samples_2017 + mfv_stopdbardbar_samples_2017 + HToSSTobbbb_samples_2017 + HToSSTodddd_samples_2017 + ZH_HToSSTodddd_ZToLL_samples_2017 + ZH_HToSSTobbbb_ZToLL_samples_2017
 
 for s in all_signal_samples_2017:
     _set_signal_stuff(s)
@@ -395,6 +433,8 @@ __all__ = [
     'mfv_stopdbardbar_samples_2017',
     'HToSSTobbbb_samples_2017',
     'HToSSTodddd_samples_2017',
+    'ZH_HToSSTodddd_ZToLL_samples_2017',
+    'ZH_HToSSTobbbb_ZToLL_samples_2017',
     'qcd_samples_2018',
     'ttbar_samples_2018',
     'bjet_samples_2018',
@@ -419,12 +459,16 @@ for x in __all__:
 
 span_signal_samples_2017 = [eval('mfv_%s_tau%06ium_M%04i_2017' % (a,b,c)) for a in ('neu','stopdbardbar') for b in (300,1000,10000) for c in (400,800,1600,3000)]
 span_signal_samples_2018 = [eval('mfv_%s_tau%06ium_M%04i_2018' % (a,b,c)) for a in ('neu','stopdbardbar') for b in (300,1000,10000) for c in (400,800,1600,3000)]
+assoc_higgs_b_samples_2017 = [eval('ZH_HToSSTobbbb_ZToll_tau%06ium_M%02i_2017' % (a,b)) for a in (50, 1000, 10000, 100000) for b in (15, 40, 55)]
+assoc_higgs_d_samples_2017 = [eval('ZH_HToSSTodddd_ZToll_tau%06ium_M%02i_2017' % (a,b)) for a in (50, 1000, 10000, 100000) for b in (7, 15, 40, 55)] 
 
 _alls = [
     'all_signal_samples_2017',
     'all_signal_samples_2018',
     'span_signal_samples_2017',
     'span_signal_samples_2018',
+    'assoc_higgs_b_samples_2017',
+    'assoc_higgs_d_samples_2017',
     ]
 __all__ += _alls
 for x in _alls:
@@ -619,6 +663,10 @@ for sample in HToSSTobbbb_samples_2017 :
     sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
 for sample in HToSSTodddd_samples_2017 :
     sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+for sample in ZH_HToSSTobbbb_ZToLL_samples_2017 :
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+for sample in ZH_HToSSTodddd_ZToLL_samples_2017 :
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
 
 ########
 # ntuples
@@ -696,10 +744,10 @@ condorable = {
         "miniaod": [qcdht0500_2018, ttHbb_2017, ggHToSSTobbbb_tau1000mm_M40_2017, ggHToSSTobbbb_tau100mm_M40_2017, ggHToSSTodddd_tau1000mm_M15_2017, ggHToSSTodddd_tau1mm_M55_2017],
         },
     "T2_US_Florida": {
-        "miniaod": [ttbar_2018, ttZext_2017, qcdht0700_2017, qcdht0500_2017],
+        "miniaod": [ttbar_2018, ttZext_2017, qcdht0700_2017, qcdht0500_2017, ZH_HToSSTodddd_ZToll_tau000050um_M07_2017, ZH_HToSSTodddd_ZToll_tau001000um_M07_2017, ZH_HToSSTodddd_ZToll_tau010000um_M07_2017, ZH_HToSSTodddd_ZToll_tau100000um_M07_2017, ZH_HToSSTodddd_ZToll_tau000050um_M15_2017, ZH_HToSSTodddd_ZToll_tau001000um_M15_2017, ZH_HToSSTodddd_ZToll_tau010000um_M15_2017, ZH_HToSSTodddd_ZToll_tau100000um_M15_2017, ZH_HToSSTodddd_ZToll_tau000050um_M40_2017, ZH_HToSSTodddd_ZToll_tau001000um_M40_2017, ZH_HToSSTodddd_ZToll_tau010000um_M40_2017, ZH_HToSSTodddd_ZToll_tau100000um_M40_2017, ZH_HToSSTodddd_ZToll_tau000050um_M55_2017, ZH_HToSSTodddd_ZToll_tau001000um_M55_2017, ZH_HToSSTodddd_ZToll_tau010000um_M55_2017, ZH_HToSSTodddd_ZToll_tau100000um_M55_2017],
         },
     "T2_US_Nebraska": {
-        "miniaod": [SingleMuon2017C, ttbar_2017, qcdht0300_2017, mfv_neu_tau030000um_M1600_2017, ggHToSSTodddd_tau10mm_M40_2017, ggHToSSTodddd_tau1000mm_M55_2017, ggHToSSTodddd_tau100mm_M55_2017],
+        "miniaod": [SingleMuon2017C, ttbar_2017, qcdht0300_2017, mfv_neu_tau030000um_M1600_2017, ggHToSSTodddd_tau10mm_M40_2017, ggHToSSTodddd_tau1000mm_M55_2017, ggHToSSTodddd_tau100mm_M55_2017, ZH_HToSSTobbbb_ZToll_tau000050um_M15_2017, ZH_HToSSTobbbb_ZToll_tau001000um_M15_2017, ZH_HToSSTobbbb_ZToll_tau010000um_M15_2017, ZH_HToSSTobbbb_ZToll_tau100000um_M15_2017, ZH_HToSSTobbbb_ZToll_tau000050um_M40_2017, ZH_HToSSTobbbb_ZToll_tau001000um_M40_2017, ZH_HToSSTobbbb_ZToll_tau010000um_M40_2017, ZH_HToSSTobbbb_ZToll_tau100000um_M40_2017, ZH_HToSSTobbbb_ZToll_tau000050um_M55_2017, ZH_HToSSTobbbb_ZToll_tau001000um_M55_2017, ZH_HToSSTobbbb_ZToll_tau010000um_M55_2017, ZH_HToSSTobbbb_ZToll_tau100000um_M55_2017],
         },
     "T2_US_Purdue": {
         "miniaod": [mfv_stopdbardbar_tau000100um_M1200_2017, ggHToSSTobbbb_tau1000mm_M15_2017, ggHToSSTobbbb_tau100mm_M15_2017, ggHToSSTobbbb_tau1mm_M15_2017, ggHToSSTobbbb_tau10mm_M40_2017, ggHToSSTobbbb_tau1mm_M40_2017, ggHToSSTobbbb_tau1000mm_M55_2017, ggHToSSTobbbb_tau100mm_M55_2017, ggHToSSTobbbb_tau1mm_M55_2017, ggHToSSTodddd_tau100mm_M15_2017, ggHToSSTodddd_tau10mm_M15_2017, ggHToSSTodddd_tau100mm_M40_2017, ggHToSSTodddd_tau1mm_M40_2017, ggHToSSTodddd_tau10mm_M55_2017],

--- a/Tools/python/Samples.py
+++ b/Tools/python/Samples.py
@@ -15,6 +15,7 @@ def _tau(sample):
     x = int(s[s.index('tau')+3:s.index('um_' if is_um else 'mm_')])
     if not is_um:
         x *= 1000
+        
     return x
 
 def _mass(sample):
@@ -50,7 +51,13 @@ def _decay(sample):
         'ggHToSSTodddd' : r'ggH \rightarrow SS \rightarrow d\bar{d}d\bar{d}',
         'ZH_HToSSTodddd_ZToll' : r'ZH \rightarrow SS \rightarrow d\bar{d}d\bar{d}, Z \rightarrow ll', 
         'ZH_HToSSTobbbb_ZToll' : r'ZH \rightarrow SS \rightarrow b\bar{b}b\bar{b}, Z \rightarrow ll', 
-        'ZH_HToSSTo4Tau_ZToll' : r'ZH \rightarrow SS \rightarrow \tau\tau\tau\tau, Z \rightarrow ll', 
+        'ZH_HToSSTo4Tau_ZToll' : r'ZH \rightarrow SS \rightarrow \tau\tau\tau\tau, Z \rightarrow ll',
+        'WpH_HToSSTo4Tau_WToLNu' : r'W^+H \rightarrow SS \rightarrow \tau\tau\tau\tau, W \rightarrow l\nu',
+        'WpH_HToSSTobbbb_WToLNu' : r'W^+H \rightarrow SS \rightarrow b\bar{b}b\bar{b}, W \rightarrow l\nu',
+        'WpH_HToSSTodddd_WToLNu' : r'W^+H \rightarrow SS \rightarrow d\bar{d}d\bar{d}, W \rightarrow l\nu',
+        'WmH_HToSSTo4Tau_WToLNu' : r'W^-H \rightarrow SS \rightarrow \tau\tau\tau\tau, W \rightarrow l\nu',
+        'WmH_HToSSTobbbb_WToLNu' : r'W^-H \rightarrow SS \rightarrow b\bar{b}b\bar{b}, W \rightarrow l\nu',
+        'WmH_HToSSTodddd_WToLNu' : r'W^-H \rightarrow SS \rightarrow d\bar{d}d\bar{d}, W \rightarrow l\nu',
         }[_model(s)]
     year = int(s.rsplit('_')[-1])
     assert 2015 <= year <= 2018
@@ -66,6 +73,16 @@ def _latex(sample):
         tau = '%4i\mm' % (tau/1000)
     return r'$%s$,   $c\tau = %s$, $M = %4s\GeV$' % (_decay(sample), tau, _mass(sample))
 
+def _rp(sample):
+    s = sample if type(sample) == str else sample.name
+
+    rp = False
+    rp_list = ['ZH', 'WmH', 'WpH']
+    for i in rp_list :
+        if s.startswith(i) :     
+            rp = True
+    return rp
+
 def _set_signal_stuff(sample):
     sample.is_signal = True
     sample.model = _model(sample)
@@ -75,6 +92,7 @@ def _set_signal_stuff(sample):
     sample.latex = _latex(sample)
     sample.xsec = 1e-3
     sample.is_private = sample.dataset.startswith('/mfv_')
+    sample.is_rp = _rp(sample)
     if sample.is_private:
         sample.dbs_inst = 'phys03'
         sample.condor = True
@@ -277,7 +295,115 @@ ZH_HToSSTodddd_ZToLL_samples_2017 = [
     MCSample('ZH_HToSSTodddd_ZToll_tau100000um_M55_2017', '/ZH_HToSSTodddd_ZToLL_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v1/MINIAODSIM', 1548790),
 ]
 
-all_signal_samples_2017 = mfv_signal_samples_2017 + mfv_stopdbardbar_samples_2017 + HToSSTobbbb_samples_2017 + HToSSTodddd_samples_2017 + ZH_HToSSTodddd_ZToLL_samples_2017 + ZH_HToSSTobbbb_ZToLL_samples_2017
+WpH_HToSSTo4Tau_WToLNu_samples_2017 = [
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau000050um_M07_2017', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 75000),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau001000um_M07_2017', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 75000),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau010000um_M07_2017', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 75000),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau100000um_M07_2017', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 75000),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau000050um_M15_2017', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 75000),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau001000um_M15_2017', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 75000),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau010000um_M15_2017', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 75000),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau100000um_M15_2017', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 75000),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau000050um_M40_2017', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 75000),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau001000um_M40_2017', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 75000),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau010000um_M40_2017', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 75000),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau100000um_M40_2017', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 75000),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau000050um_M55_2017', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 75000),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau001000um_M55_2017', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 75000),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau010000um_M55_2017', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 75000),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau100000um_M55_2017', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 75000),
+]
+
+WpH_HToSSTobbbb_WToLNu_samples_2017 = [
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau000050um_M15_2017', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1717617),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau001000um_M15_2017', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1717617),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau010000um_M15_2017', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1717617),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau100000um_M15_2017', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1717617),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau000050um_M40_2017', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1717617),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau001000um_M40_2017', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1717617),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau010000um_M40_2017', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1717617),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau100000um_M40_2017', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1717617),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau000050um_M55_2017', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1717617),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau001000um_M55_2017', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1717617),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau010000um_M55_2017', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1717617),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau100000um_M55_2017', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1717617),
+]
+
+
+WpH_HToSSTodddd_WToLNu_samples_2017 = [
+    MCSample('WpH_HToSSTodddd_WToLNu_tau000050um_M07_2017', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 2273799),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau001000um_M07_2017', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 2273799),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau010000um_M07_2017', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 2273799),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau100000um_M07_2017', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 2273799),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau000050um_M15_2017', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 2273799),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau001000um_M15_2017', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 2273799),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau010000um_M15_2017', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 2273799),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau100000um_M15_2017', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 2273799),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau000050um_M40_2017', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 2273799),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau001000um_M40_2017', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 2273799),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau010000um_M40_2017', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 2273799),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau100000um_M40_2017', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 2273799),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau000050um_M55_2017', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 2273799),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau001000um_M55_2017', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 2273799),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau010000um_M55_2017', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 2273799),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau100000um_M55_2017', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 2273799),
+]
+
+WmH_HToSSTo4Tau_WToLNu_samples_2017 = [
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau000050um_M07_2017', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514050),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau001000um_M07_2017', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514050),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau010000um_M07_2017', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514050),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau100000um_M07_2017', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514050),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau000050um_M15_2017', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514050),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau001000um_M15_2017', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514050),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau010000um_M15_2017', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514050),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau100000um_M15_2017', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514050),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau000050um_M40_2017', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514050),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau001000um_M40_2017', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514050),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau010000um_M40_2017', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514050),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau100000um_M40_2017', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514050),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau000050um_M55_2017', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514050),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau001000um_M55_2017', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514050),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau010000um_M55_2017', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514050),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau100000um_M55_2017', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514050),
+]
+
+WmH_HToSSTobbbb_WToLNu_samples_2017 = [
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau000050um_M15_2017', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1118148),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau001000um_M15_2017', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1118148),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau010000um_M15_2017', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1118148),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau100000um_M15_2017', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1118148),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau000050um_M40_2017', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1118148),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau001000um_M40_2017', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1118148),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau010000um_M40_2017', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1118148),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau100000um_M40_2017', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1118148),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau000050um_M55_2017', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1118148),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau001000um_M55_2017', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1118148),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau010000um_M55_2017', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1118148),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau100000um_M55_2017', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1118148),
+]
+
+WmH_HToSSTodddd_WToLNu_samples_2017 = [
+    MCSample('WmH_HToSSTodddd_WToLNu_tau000050um_M07_2017', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514429),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau001000um_M07_2017', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514429),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau010000um_M07_2017', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514429),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau100000um_M07_2017', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514429),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau000050um_M15_2017', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514429),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau001000um_M15_2017', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514429),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau010000um_M15_2017', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514429),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau100000um_M15_2017', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514429),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau000050um_M40_2017', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514429),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau001000um_M40_2017', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514429),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau010000um_M40_2017', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514429),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau100000um_M40_2017', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514429),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau000050um_M55_2017', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514429),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau001000um_M55_2017', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514429),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau010000um_M55_2017', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514429),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau100000um_M55_2017', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIFall17MiniAODv2-PU2017_12Apr2018_rp_94X_mc2017_realistic_v14-v2/MINIAODSIM', 1514429),
+]
+
+all_signal_samples_2017 = mfv_signal_samples_2017 + mfv_stopdbardbar_samples_2017 + HToSSTobbbb_samples_2017 + HToSSTodddd_samples_2017 + ZH_HToSSTodddd_ZToLL_samples_2017 + ZH_HToSSTobbbb_ZToLL_samples_2017 + WpH_HToSSTo4Tau_WToLNu_samples_2017 + WmH_HToSSTo4Tau_WToLNu_samples_2017  + WmH_HToSSTobbbb_WToLNu_samples_2017 + WmH_HToSSTodddd_WToLNu_samples_2017 + WpH_HToSSTobbbb_WToLNu_samples_2017 + WpH_HToSSTodddd_WToLNu_samples_2017
+
 
 for s in all_signal_samples_2017:
     _set_signal_stuff(s)
@@ -373,7 +499,115 @@ mfv_stopdbardbar_samples_2018 = [
     MCSample('mfv_stopdbardbar_tau030000um_M3000_2018', '/StopStopbarTo2Dbar2D_M-3000_CTau-30mm_TuneCP2_13TeV_2018-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/AODSIM', 100000),
     ]
 
-all_signal_samples_2018 = mfv_signal_samples_2018 + mfv_stopdbardbar_samples_2018
+WpH_HToSSTo4Tau_WToLNu_samples_2018 = [
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau000050um_M07_2018', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau001000um_M07_2018', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau010000um_M07_2018', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau100000um_M07_2018', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau000050um_M15_2018', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau001000um_M15_2018', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau010000um_M15_2018', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau100000um_M15_2018', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau000050um_M40_2018', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau001000um_M40_2018', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau010000um_M40_2018', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau100000um_M40_2018', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau000050um_M55_2018', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau001000um_M55_2018', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau010000um_M55_2018', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+    MCSample('WpH_HToSSTo4Tau_WToLNu_tau100000um_M55_2018', '/WplusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+]
+
+WpH_HToSSTobbbb_WToLNu_samples_2018 = [
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau000050um_M15_2018', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1724908),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau001000um_M15_2018', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1724908),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau010000um_M15_2018', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1724908),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau100000um_M15_2018', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1724908),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau000050um_M40_2018', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1724908),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau001000um_M40_2018', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1724908),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau010000um_M40_2018', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1724908),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau100000um_M40_2018', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1724908),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau000050um_M55_2018', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1724908),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau001000um_M55_2018', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1724908),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau010000um_M55_2018', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1724908),
+    MCSample('WpH_HToSSTobbbb_WToLNu_tau100000um_M55_2018', '/WplusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1724908),
+]
+
+WpH_HToSSTodddd_WToLNu_samples_2018 = [
+    MCSample('WpH_HToSSTodddd_WToLNu_tau000050um_M07_2018', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2307993),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau001000um_M07_2018', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2307993),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau010000um_M07_2018', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2307993),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau100000um_M07_2018', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2307993),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau000050um_M15_2018', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2307993),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau001000um_M15_2018', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2307993),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau010000um_M15_2018', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2307993),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau100000um_M15_2018', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2307993),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau000050um_M40_2018', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2307993),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau001000um_M40_2018', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2307993),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau010000um_M40_2018', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2307993),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau100000um_M40_2018', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2307993),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau000050um_M55_2018', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2307993),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau001000um_M55_2018', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2307993),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau010000um_M55_2018', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2307993),
+    MCSample('WpH_HToSSTodddd_WToLNu_tau100000um_M55_2018', '/WplusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2307993),
+]
+
+WmH_HToSSTo4Tau_WToLNu_samples_2018 = [
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau000050um_M07_2018', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1499427),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau001000um_M07_2018', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1499427),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau010000um_M07_2018', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1499427),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau100000um_M07_2018', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1499427),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau000050um_M15_2018', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1499427),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau001000um_M15_2018', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1499427),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau010000um_M15_2018', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1499427),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau100000um_M15_2018', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1499427),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau000050um_M40_2018', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1499427),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau001000um_M40_2018', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1499427),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau010000um_M40_2018', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1499427),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau100000um_M40_2018', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1499427),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau000050um_M55_2018', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1499427),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau001000um_M55_2018', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1499427),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau010000um_M55_2018', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1499427),
+    MCSample('WmH_HToSSTo4Tau_WToLNu_tau100000um_M55_2018', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1499427),
+]
+
+# #INVALID
+# WmH_HToSSTobbbb_WToLNu_samples_2018 = [
+#     MCSample('WmH_HToSSTobbbb_WToLNu_tau000050um_M15_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+#     MCSample('WmH_HToSSTobbbb_WToLNu_tau001000um_M15_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+#     MCSample('WmH_HToSSTobbbb_WToLNu_tau010000um_M15_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+#     MCSample('WmH_HToSSTobbbb_WToLNu_tau100000um_M15_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+#     MCSample('WmH_HToSSTobbbb_WToLNu_tau000050um_M40_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+#     MCSample('WmH_HToSSTobbbb_WToLNu_tau001000um_M40_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+#     MCSample('WmH_HToSSTobbbb_WToLNu_tau010000um_M40_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+#     MCSample('WmH_HToSSTobbbb_WToLNu_tau100000um_M40_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+#     MCSample('WmH_HToSSTobbbb_WToLNu_tau000050um_M55_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+#     MCSample('WmH_HToSSTobbbb_WToLNu_tau001000um_M55_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+#     MCSample('WmH_HToSSTobbbb_WToLNu_tau010000um_M55_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+#     MCSample('WmH_HToSSTobbbb_WToLNu_tau100000um_M55_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
+# ]
+
+WmH_HToSSTodddd_WToLNu_samples_2018 = [
+    MCSample('WmH_HToSSTodddd_WToLNu_tau000050um_M07_2018', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1533189),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau001000um_M07_2018', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1533189),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau010000um_M07_2018', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1533189),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau100000um_M07_2018', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1533189),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau000050um_M15_2018', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1533189),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau001000um_M15_2018', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1533189),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau010000um_M15_2018', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1533189),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau100000um_M15_2018', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1533189),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau000050um_M40_2018', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1533189),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau001000um_M40_2018', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1533189),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau010000um_M40_2018', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1533189),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau100000um_M40_2018', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1533189),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau000050um_M55_2018', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1533189),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau001000um_M55_2018', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1533189),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau010000um_M55_2018', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1533189),
+    MCSample('WmH_HToSSTodddd_WToLNu_tau100000um_M55_2018', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1533189),
+]
+
+all_signal_samples_2018 = mfv_signal_samples_2018 + mfv_stopdbardbar_samples_2018 + WpH_HToSSTo4Tau_WToLNu_samples_2018 + WpH_HToSSTobbbb_WToLNu_samples_2018 + WpH_HToSSTodddd_WToLNu_samples_2018 + WmH_HToSSTo4Tau_WToLNu_samples_2018 + WmH_HToSSTodddd_WToLNu_samples_2018
+
 
 for s in all_signal_samples_2018:
     _set_signal_stuff(s)
@@ -435,11 +669,23 @@ __all__ = [
     'HToSSTodddd_samples_2017',
     'ZH_HToSSTodddd_ZToLL_samples_2017',
     'ZH_HToSSTobbbb_ZToLL_samples_2017',
+    'WpH_HToSSTo4Tau_WToLNu_samples_2017',
+    'WpH_HToSSTobbbb_WToLNu_samples_2017',
+    'WpH_HToSSTodddd_WToLNu_samples_2017',
+    'WmH_HToSSTo4Tau_WToLNu_samples_2017',
+    'WmH_HToSSTobbbb_WToLNu_samples_2017',
+    'WmH_HToSSTodddd_WToLNu_samples_2017',
     'qcd_samples_2018',
     'ttbar_samples_2018',
     'bjet_samples_2018',
     'mfv_signal_samples_2018',
     'mfv_stopdbardbar_samples_2018',
+    'WpH_HToSSTo4Tau_WToLNu_samples_2018',
+    'WpH_HToSSTobbbb_WToLNu_samples_2018',
+    'WpH_HToSSTodddd_WToLNu_samples_2018',
+    'WmH_HToSSTo4Tau_WToLNu_samples_2018',
+    #'WmH_HToSSTobbbb_WToLNu_samples_2018',
+    'WmH_HToSSTodddd_WToLNu_samples_2018',
     'data_samples_2017',
     'auxiliary_data_samples_2017',
     'data_samples_2018',
@@ -459,17 +705,14 @@ for x in __all__:
 
 span_signal_samples_2017 = [eval('mfv_%s_tau%06ium_M%04i_2017' % (a,b,c)) for a in ('neu','stopdbardbar') for b in (300,1000,10000) for c in (400,800,1600,3000)]
 span_signal_samples_2018 = [eval('mfv_%s_tau%06ium_M%04i_2018' % (a,b,c)) for a in ('neu','stopdbardbar') for b in (300,1000,10000) for c in (400,800,1600,3000)]
-assoc_higgs_b_samples_2017 = [eval('ZH_HToSSTobbbb_ZToll_tau%06ium_M%02i_2017' % (a,b)) for a in (50, 1000, 10000, 100000) for b in (15, 40, 55)]
-assoc_higgs_d_samples_2017 = [eval('ZH_HToSSTodddd_ZToll_tau%06ium_M%02i_2017' % (a,b)) for a in (50, 1000, 10000, 100000) for b in (7, 15, 40, 55)] 
 
 _alls = [
     'all_signal_samples_2017',
     'all_signal_samples_2018',
     'span_signal_samples_2017',
     'span_signal_samples_2018',
-    'assoc_higgs_b_samples_2017',
-    'assoc_higgs_d_samples_2017',
     ]
+
 __all__ += _alls
 for x in _alls:
     registry.add_list(x, eval(x))
@@ -667,6 +910,31 @@ for sample in ZH_HToSSTobbbb_ZToLL_samples_2017 :
     sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
 for sample in ZH_HToSSTodddd_ZToLL_samples_2017 :
     sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+for sample in WmH_HToSSTo4Tau_WToLNu_samples_2017 :
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+for sample in WmH_HToSSTobbbb_WToLNu_samples_2017 :
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+for sample in WmH_HToSSTodddd_WToLNu_samples_2017 :
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+for sample in WpH_HToSSTo4Tau_WToLNu_samples_2017 :
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+for sample in WpH_HToSSTobbbb_WToLNu_samples_2017 :
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+for sample in WpH_HToSSTodddd_WToLNu_samples_2017 :
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+    
+for sample in WmH_HToSSTo4Tau_WToLNu_samples_2018 :
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+# for sample in WmH_HToSSTobbbb_WToLNu_samples_2018 :
+#     sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+for sample in WmH_HToSSTodddd_WToLNu_samples_2018 :
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+for sample in WpH_HToSSTo4Tau_WToLNu_samples_2018 :
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+for sample in WpH_HToSSTobbbb_WToLNu_samples_2018 :
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+for sample in WpH_HToSSTodddd_WToLNu_samples_2018 :
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
 
 ########
 # ntuples
@@ -732,7 +1000,7 @@ condorable = {
                                          mfv_neu_tau000100um_M0400_2018, mfv_neu_tau000100um_M0600_2018, mfv_neu_tau000100um_M0800_2018, mfv_neu_tau000100um_M1200_2018, mfv_neu_tau000100um_M1600_2018, mfv_neu_tau000100um_M3000_2018, mfv_neu_tau000300um_M0400_2018, mfv_neu_tau000300um_M0600_2018, mfv_neu_tau000300um_M0800_2018, mfv_neu_tau000300um_M1200_2018, mfv_neu_tau000300um_M1600_2018, mfv_neu_tau000300um_M3000_2018, mfv_neu_tau001000um_M0400_2018, mfv_neu_tau001000um_M0600_2018, mfv_neu_tau001000um_M1200_2018, mfv_neu_tau001000um_M1600_2018, mfv_neu_tau001000um_M3000_2018, mfv_neu_tau010000um_M0400_2018, mfv_neu_tau010000um_M0600_2018, mfv_neu_tau010000um_M0800_2018, mfv_neu_tau010000um_M1200_2018, mfv_neu_tau010000um_M1600_2018, mfv_neu_tau010000um_M3000_2018, mfv_neu_tau030000um_M0400_2018, mfv_neu_tau030000um_M0600_2018, mfv_neu_tau030000um_M0800_2018, mfv_neu_tau030000um_M1200_2018, mfv_neu_tau030000um_M1600_2018, mfv_neu_tau030000um_M3000_2018, mfv_stopdbardbar_tau000100um_M0400_2018, mfv_stopdbardbar_tau000100um_M0600_2018, mfv_stopdbardbar_tau000100um_M0800_2018, mfv_stopdbardbar_tau000100um_M1200_2018, mfv_stopdbardbar_tau000100um_M3000_2018, mfv_stopdbardbar_tau000300um_M0600_2018, mfv_stopdbardbar_tau000300um_M0800_2018, mfv_stopdbardbar_tau000300um_M1200_2018, mfv_stopdbardbar_tau000300um_M3000_2018, mfv_stopdbardbar_tau001000um_M0400_2018, mfv_stopdbardbar_tau001000um_M0600_2018, mfv_stopdbardbar_tau001000um_M0800_2018, mfv_stopdbardbar_tau001000um_M1200_2018, mfv_stopdbardbar_tau001000um_M1600_2018, mfv_stopdbardbar_tau001000um_M3000_2018, mfv_stopdbardbar_tau010000um_M0400_2018, mfv_stopdbardbar_tau010000um_M0600_2018, mfv_stopdbardbar_tau010000um_M0800_2018, mfv_stopdbardbar_tau010000um_M1600_2018, mfv_stopdbardbar_tau030000um_M0400_2018, mfv_stopdbardbar_tau030000um_M0600_2018, mfv_stopdbardbar_tau030000um_M0800_2018, mfv_stopdbardbar_tau030000um_M1200_2018, mfv_stopdbardbar_tau030000um_M3000_2018],
         },
     "T1_US_FNAL_Disk": {
-        "miniaod": [qcdht1500_2017, qcdht2000_2017, dyjetstollM10_2017, qcdmupt15_2017, qcdht0300_2018, qcdht0700_2018, ttbarht0800_2018,
+        "miniaod": WpH_HToSSTobbbb_WToLNu_samples_2018 + WpH_HToSSTodddd_WToLNu_samples_2018 + WmH_HToSSTodddd_WToLNu_samples_2018 + WpH_HToSSTodddd_WToLNu_samples_2017 + WmH_HToSSTobbbb_WToLNu_samples_2017 + WmH_HToSSTodddd_WToLNu_samples_2017 + [qcdht1500_2017, qcdht2000_2017, dyjetstollM10_2017, qcdmupt15_2017, qcdht0300_2018, qcdht0700_2018, ttbarht0800_2018,
                     JetHT2017B, JetHT2017D, JetHT2017F, JetHT2018A, JetHT2018B, JetHT2018D,
                     mfv_neu_tau000100um_M0600_2017, mfv_neu_tau000300um_M0400_2017, mfv_neu_tau000300um_M0800_2017, mfv_neu_tau000300um_M3000_2017, mfv_neu_tau010000um_M0400_2017, mfv_neu_tau010000um_M0800_2017, mfv_neu_tau010000um_M1600_2017, mfv_neu_tau030000um_M0800_2017, mfv_neu_tau030000um_M3000_2017, mfv_stopdbardbar_tau000100um_M0600_2017, mfv_stopdbardbar_tau000100um_M1600_2017, mfv_stopdbardbar_tau000300um_M1200_2017, mfv_stopdbardbar_tau001000um_M0400_2017, mfv_stopdbardbar_tau001000um_M1200_2017, mfv_stopdbardbar_tau001000um_M3000_2017, mfv_stopdbardbar_tau010000um_M0800_2017, mfv_stopdbardbar_tau010000um_M3000_2017, mfv_stopdbardbar_tau030000um_M1200_2017, mfv_stopdbardbar_tau030000um_M1600_2017,
                     mfv_neu_tau001000um_M0800_2018, mfv_stopdbardbar_tau000100um_M1600_2018, mfv_stopdbardbar_tau000300um_M0400_2018, mfv_stopdbardbar_tau000300um_M1600_2018, mfv_stopdbardbar_tau010000um_M1200_2018, mfv_stopdbardbar_tau010000um_M3000_2018, mfv_stopdbardbar_tau030000um_M1600_2018, SingleMuon2017F, ggHToSSTobbbb_tau10mm_M15_2017, ggHToSSTodddd_tau1mm_M15_2017, ggHToSSTodddd_tau1000mm_M40_2017],
@@ -744,13 +1012,13 @@ condorable = {
         "miniaod": [qcdht0500_2018, ttHbb_2017, ggHToSSTobbbb_tau1000mm_M40_2017, ggHToSSTobbbb_tau100mm_M40_2017, ggHToSSTodddd_tau1000mm_M15_2017, ggHToSSTodddd_tau1mm_M55_2017],
         },
     "T2_US_Florida": {
-        "miniaod": [ttbar_2018, ttZext_2017, qcdht0700_2017, qcdht0500_2017, ZH_HToSSTodddd_ZToll_tau000050um_M07_2017, ZH_HToSSTodddd_ZToll_tau001000um_M07_2017, ZH_HToSSTodddd_ZToll_tau010000um_M07_2017, ZH_HToSSTodddd_ZToll_tau100000um_M07_2017, ZH_HToSSTodddd_ZToll_tau000050um_M15_2017, ZH_HToSSTodddd_ZToll_tau001000um_M15_2017, ZH_HToSSTodddd_ZToll_tau010000um_M15_2017, ZH_HToSSTodddd_ZToll_tau100000um_M15_2017, ZH_HToSSTodddd_ZToll_tau000050um_M40_2017, ZH_HToSSTodddd_ZToll_tau001000um_M40_2017, ZH_HToSSTodddd_ZToll_tau010000um_M40_2017, ZH_HToSSTodddd_ZToll_tau100000um_M40_2017, ZH_HToSSTodddd_ZToll_tau000050um_M55_2017, ZH_HToSSTodddd_ZToll_tau001000um_M55_2017, ZH_HToSSTodddd_ZToll_tau010000um_M55_2017, ZH_HToSSTodddd_ZToll_tau100000um_M55_2017],
+        "miniaod": ZH_HToSSTodddd_ZToLL_samples_2017 + [ttbar_2018, ttZext_2017, qcdht0700_2017, qcdht0500_2017],
         },
     "T2_US_Nebraska": {
-        "miniaod": [SingleMuon2017C, ttbar_2017, qcdht0300_2017, mfv_neu_tau030000um_M1600_2017, ggHToSSTodddd_tau10mm_M40_2017, ggHToSSTodddd_tau1000mm_M55_2017, ggHToSSTodddd_tau100mm_M55_2017, ZH_HToSSTobbbb_ZToll_tau000050um_M15_2017, ZH_HToSSTobbbb_ZToll_tau001000um_M15_2017, ZH_HToSSTobbbb_ZToll_tau010000um_M15_2017, ZH_HToSSTobbbb_ZToll_tau100000um_M15_2017, ZH_HToSSTobbbb_ZToll_tau000050um_M40_2017, ZH_HToSSTobbbb_ZToll_tau001000um_M40_2017, ZH_HToSSTobbbb_ZToll_tau010000um_M40_2017, ZH_HToSSTobbbb_ZToll_tau100000um_M40_2017, ZH_HToSSTobbbb_ZToll_tau000050um_M55_2017, ZH_HToSSTobbbb_ZToll_tau001000um_M55_2017, ZH_HToSSTobbbb_ZToll_tau010000um_M55_2017, ZH_HToSSTobbbb_ZToll_tau100000um_M55_2017],
+        "miniaod": ZH_HToSSTobbbb_ZToLL_samples_2017 + WpH_HToSSTo4Tau_WToLNu_samples_2018 + WpH_HToSSTobbbb_WToLNu_samples_2017 + [SingleMuon2017C, ttbar_2017, qcdht0300_2017, mfv_neu_tau030000um_M1600_2017, ggHToSSTodddd_tau10mm_M40_2017, ggHToSSTodddd_tau1000mm_M55_2017, ggHToSSTodddd_tau100mm_M55_2017],
         },
     "T2_US_Purdue": {
-        "miniaod": [mfv_stopdbardbar_tau000100um_M1200_2017, ggHToSSTobbbb_tau1000mm_M15_2017, ggHToSSTobbbb_tau100mm_M15_2017, ggHToSSTobbbb_tau1mm_M15_2017, ggHToSSTobbbb_tau10mm_M40_2017, ggHToSSTobbbb_tau1mm_M40_2017, ggHToSSTobbbb_tau1000mm_M55_2017, ggHToSSTobbbb_tau100mm_M55_2017, ggHToSSTobbbb_tau1mm_M55_2017, ggHToSSTodddd_tau100mm_M15_2017, ggHToSSTodddd_tau10mm_M15_2017, ggHToSSTodddd_tau100mm_M40_2017, ggHToSSTodddd_tau1mm_M40_2017, ggHToSSTodddd_tau10mm_M55_2017],
+        "miniaod": WmH_HToSSTo4Tau_WToLNu_samples_2017 + WpH_HToSSTo4Tau_WToLNu_samples_2017 + WmH_HToSSTo4Tau_WToLNu_samples_2018 + [mfv_stopdbardbar_tau000100um_M1200_2017, ggHToSSTobbbb_tau1000mm_M15_2017, ggHToSSTobbbb_tau100mm_M15_2017, ggHToSSTobbbb_tau1mm_M15_2017, ggHToSSTobbbb_tau10mm_M40_2017, ggHToSSTobbbb_tau1mm_M40_2017, ggHToSSTobbbb_tau1000mm_M55_2017, ggHToSSTobbbb_tau100mm_M55_2017, ggHToSSTobbbb_tau1mm_M55_2017, ggHToSSTodddd_tau100mm_M15_2017, ggHToSSTodddd_tau10mm_M15_2017, ggHToSSTodddd_tau100mm_M40_2017, ggHToSSTodddd_tau1mm_M40_2017, ggHToSSTodddd_tau10mm_M55_2017],
         },
     "T2_US_Wisconsin" : {
         "miniaod": [ttZ_2017, mfv_stopdbardbar_tau000300um_M0600_2017, ggHToSSTobbbb_tau10mm_M55_2017],

--- a/Tools/python/Samples.py
+++ b/Tools/python/Samples.py
@@ -571,21 +571,20 @@ WmH_HToSSTo4Tau_WToLNu_samples_2018 = [
     MCSample('WmH_HToSSTo4Tau_WToLNu_tau100000um_M55_2018', '/WminusH_HToSSTo4Tau_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1499427),
 ]
 
-# #INVALID
-# WmH_HToSSTobbbb_WToLNu_samples_2018 = [
-#     MCSample('WmH_HToSSTobbbb_WToLNu_tau000050um_M15_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
-#     MCSample('WmH_HToSSTobbbb_WToLNu_tau001000um_M15_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
-#     MCSample('WmH_HToSSTobbbb_WToLNu_tau010000um_M15_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
-#     MCSample('WmH_HToSSTobbbb_WToLNu_tau100000um_M15_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
-#     MCSample('WmH_HToSSTobbbb_WToLNu_tau000050um_M40_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
-#     MCSample('WmH_HToSSTobbbb_WToLNu_tau001000um_M40_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
-#     MCSample('WmH_HToSSTobbbb_WToLNu_tau010000um_M40_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
-#     MCSample('WmH_HToSSTobbbb_WToLNu_tau100000um_M40_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
-#     MCSample('WmH_HToSSTobbbb_WToLNu_tau000050um_M55_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
-#     MCSample('WmH_HToSSTobbbb_WToLNu_tau001000um_M55_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
-#     MCSample('WmH_HToSSTobbbb_WToLNu_tau010000um_M55_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
-#     MCSample('WmH_HToSSTobbbb_WToLNu_tau100000um_M55_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 2300912),
-# ]
+WmH_HToSSTobbbb_WToLNu_samples_2018 = [
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau000050um_M15_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v2/MINIAODSIM', 1149932),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau001000um_M15_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v2/MINIAODSIM', 1149932),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau010000um_M15_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v2/MINIAODSIM', 1149932),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau100000um_M15_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v2/MINIAODSIM', 1149932),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau000050um_M40_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v2/MINIAODSIM', 1149932),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau001000um_M40_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v2/MINIAODSIM', 1149932),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau010000um_M40_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v2/MINIAODSIM', 1149932),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau100000um_M40_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v2/MINIAODSIM', 1149932),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau000050um_M55_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v2/MINIAODSIM', 1149932),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau001000um_M55_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v2/MINIAODSIM', 1149932),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau010000um_M55_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v2/MINIAODSIM', 1149932),
+    MCSample('WmH_HToSSTobbbb_WToLNu_tau100000um_M55_2018', '/WminusH_HToSSTobbbb_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v2/MINIAODSIM', 1149932),
+]
 
 WmH_HToSSTodddd_WToLNu_samples_2018 = [
     MCSample('WmH_HToSSTodddd_WToLNu_tau000050um_M07_2018', '/WminusH_HToSSTodddd_WToLNu_MH-125_TuneCP5_13TeV-powheg-pythia8/RunIIAutumn18MiniAOD-rp_102X_upgrade2018_realistic_v15-v1/MINIAODSIM', 1533189),
@@ -684,7 +683,7 @@ __all__ = [
     'WpH_HToSSTobbbb_WToLNu_samples_2018',
     'WpH_HToSSTodddd_WToLNu_samples_2018',
     'WmH_HToSSTo4Tau_WToLNu_samples_2018',
-    #'WmH_HToSSTobbbb_WToLNu_samples_2018',
+    'WmH_HToSSTobbbb_WToLNu_samples_2018',
     'WmH_HToSSTodddd_WToLNu_samples_2018',
     'data_samples_2017',
     'auxiliary_data_samples_2017',
@@ -925,8 +924,8 @@ for sample in WpH_HToSSTodddd_WToLNu_samples_2017 :
     
 for sample in WmH_HToSSTo4Tau_WToLNu_samples_2018 :
     sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
-# for sample in WmH_HToSSTobbbb_WToLNu_samples_2018 :
-#     sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+for sample in WmH_HToSSTobbbb_WToLNu_samples_2018 :
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
 for sample in WmH_HToSSTodddd_WToLNu_samples_2018 :
     sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
 for sample in WpH_HToSSTo4Tau_WToLNu_samples_2018 :

--- a/Tools/python/SimpleTriggerEfficiency_cfi.py
+++ b/Tools/python/SimpleTriggerEfficiency_cfi.py
@@ -3,10 +3,24 @@ import FWCore.ParameterSet.Config as cms
 SimpleTriggerEfficiency = cms.EDAnalyzer('SimpleTriggerEfficiency',
                                          trigger_results_src = cms.InputTag('TriggerResults', '', 'HLT'),
                                          weight_src = cms.InputTag(''),
+                                         parse_randpars = cms.bool(False), 
+                                         randpar_mass = cms.int32(-1),
+                                         randpar_ctau = cms.string(''),
+                                         randpar_dcay = cms.string(''),
                                          )
 
-def setup_endpath(process, weight_src = ''):
-    process.SimpleTriggerEfficiency = SimpleTriggerEfficiency.clone(weight_src = weight_src)
+def setup_endpath(process, rp_mode, weight_src = ''):
+
+    if rp_mode :
+        rp_mass = (int)(rp_mode[rp_mode.find('M')+1 : rp_mode.find('_')])
+        rp_ctau = rp_mode[rp_mode.find('t')+1 : rp_mode.find('-')]
+        rp_dcay = rp_mode[rp_mode.find('H') : rp_mode.find(' M')]
+        parse_randpars = True
+           
+        process.SimpleTriggerEfficiency = SimpleTriggerEfficiency.clone(weight_src = weight_src, parse_randpars = parse_randpars, randpar_mass = rp_mass, randpar_ctau = rp_ctau, randpar_dcay = rp_dcay)
+    else :
+        process.SimpleTriggerEfficiency = SimpleTriggerEfficiency.clone(weight_src = weight_src)
+    
     process.SimpleTriggerEfficiency.trigger_results_src = cms.InputTag('TriggerResults', '', process.name_())
     process.RandomNumberGeneratorService = cms.Service('RandomNumberGeneratorService')
     process.RandomNumberGeneratorService.SimpleTriggerEfficiency = cms.PSet(initialSeed = cms.untracked.uint32(1220))


### PR DESCRIPTION
Support for handling ZH and Wplus centrally produced MC samples which were created using a randomized parameters scheme is introduced. The configDescription string is read to filter samples based on individual mass & lifetime. 