### PR TITLE
Implementing continuous integration

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,4 +20,4 @@ jobs:
     - name: Take a look around
       run: pwd && ls -alh
     - name: Run a CVMFS Docker image and run the setup script
-      run: docker run  -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --entrypoint "/bin/bash" aperloff/cms-cvmfs-docker:light -c "/run.sh -c \"wget https://raw.githubusercontent.com/jreic/cmssw-usercode/master/initial_setup.sh && chmod +x initial_setup.sh && source initial_setup.sh \" && cvmfs_config wipecache"
+      run: docker run  -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --entrypoint "/bin/bash" aperloff/cms-cvmfs-docker:light -c "/run.sh -c \"wget https://raw.githubusercontent.com/DisplacedVertices/cmssw-usercode/master/initial_setup.sh && chmod +x initial_setup.sh && source initial_setup.sh \" && cvmfs_config wipecache"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,23 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  current_branch: $(echo ${{ github.ref }} | sed -E 's|refs/[a-zA-Z]+/||')
+  current_user: ${{ github.actor }}
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Take a look around
+      run: pwd && ls -alh
+    - name: Run a CVMFS Docker image and run the setup script
+      run: docker run  -t -P --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined -e CVMFS_MOUNTS="cms.cern.ch" --entrypoint "/bin/bash" aperloff/cms-cvmfs-docker:light -c "/run.sh -c \"wget https://raw.githubusercontent.com/jreic/cmssw-usercode/master/initial_setup.sh && chmod +x initial_setup.sh && source initial_setup.sh \" && cvmfs_config wipecache"

--- a/initial_setup.sh
+++ b/initial_setup.sh
@@ -1,0 +1,9 @@
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+scram project -n mfv_946p1 CMSSW CMSSW_9_4_6_patch1
+cd mfv_946p1/src
+cmsenv
+git cms-init --upstream-only
+git clone git@github.com:jordantucker/cmssw-usercode JMTucker
+cd JMTucker
+scram b -j 4
+source /cvmfs/cms.cern.ch/common/crab-setup.sh

--- a/initial_setup.sh
+++ b/initial_setup.sh
@@ -6,4 +6,8 @@ git cms-init --upstream-only
 git clone https://github.com/DisplacedVertices/cmssw-usercode.git JMTucker
 cd JMTucker
 scram b -j 4
+statuscode=$?
 source /cvmfs/cms.cern.ch/common/crab-setup.sh
+
+# Check the statuscode, for the purpose of the continuous integration
+[ $statuscode == 0 ]

--- a/initial_setup.sh
+++ b/initial_setup.sh
@@ -3,7 +3,7 @@ scram project -n mfv_946p1 CMSSW CMSSW_9_4_6_patch1
 cd mfv_946p1/src
 cmsenv
 git cms-init --upstream-only
-git clone git@github.com:jordantucker/cmssw-usercode JMTucker
+git clone https://github.com/DisplacedVertices/cmssw-usercode.git JMTucker
 cd JMTucker
 scram b -j 4
 source /cvmfs/cms.cern.ch/common/crab-setup.sh


### PR DESCRIPTION
Implemented CI to build our code (using cvmfs and cmssw via a Docker image) after each push to the `master` branch. 

We in principle can/should extend this to do the same for other important branches (could consider all branches, to do the same for long-term development branches), and for different releases than what I implemented it for (9_4_6_patch1).

We can also setup the CI to do other things, e.g. to download an input root file and do sanity checks of ntupling or making histograms, if we wanted to. Probably overkill for now; catching C++ compilation errors already will be useful.

Related to issue #9 