### PR TITLE
Fix issue of running over non-signal samples in rp scheme

### DIFF
--- a/MFVNeutralino/python/NtupleCommon.py
+++ b/MFVNeutralino/python/NtupleCommon.py
@@ -308,8 +308,6 @@ def ntuple_process(settings):
 # Used for samples stored in inclusive miniaods; currently set up for ZH, Wplus & Wminus
 # may need to change to handle different naming conventions 
 def signal_uses_random_pars_modifier(sample): 
-    to_replace = []
-
     if sample.is_signal:
         if sample.is_rp :
             magic_randpar = 'randpars_filter = False'
@@ -325,7 +323,11 @@ def signal_uses_random_pars_modifier(sample):
                 ctau = str(ctau).replace('.', 'p')
                 ctau = ctau.replace('p0', '')
                 
-            to_replace.append((magic_randpar, "randpars_filter = 'randpar %s M%i_ct%s-'" % (decay, sample.mass, ctau), 'tuple template does not contain the magic string "%s"' % magic_randpar))
+            to_replace = [(magic_randpar, "randpars_filter = 'randpar %s M%i_ct%s-'" % (decay, sample.mass, ctau), 'tuple template does not contain the magic string "%s"' % magic_randpar)]
+        else :
+            to_replace = []
+    else :
+        to_replace = []
     return [], to_replace
 
 

--- a/MFVNeutralino/test/ntuple.py
+++ b/MFVNeutralino/test/ntuple.py
@@ -36,7 +36,7 @@ if __name__ == '__main__' and hasattr(sys, 'argv') and 'submit' in sys.argv:
     if use_btag_triggers :
         samples = pick_samples(dataset, qcd=True, ttbar=False, all_signal=not settings.run_n_tk_seeds, data=False, bjet=True) # no data currently; no sliced ttbar since inclusive is used
     else :
-        samples = pick_samples(dataset, qcd=False, ttbar=True, data=False, all_signal=not settings.run_n_tk_seeds)
+        samples = pick_samples(dataset, qcd=False, ttbar=False, data=False, all_signal=not settings.run_n_tk_seeds)
         
     set_splitting(samples, dataset, 'ntuple', data_json=json_path('ana_2017p8.json'), limit_ttbar=True)
 

--- a/MFVNeutralino/test/ntuple.py
+++ b/MFVNeutralino/test/ntuple.py
@@ -36,7 +36,7 @@ if __name__ == '__main__' and hasattr(sys, 'argv') and 'submit' in sys.argv:
     if use_btag_triggers :
         samples = pick_samples(dataset, qcd=True, ttbar=False, all_signal=not settings.run_n_tk_seeds, data=False, bjet=True) # no data currently; no sliced ttbar since inclusive is used
     else :
-        samples = pick_samples(dataset, qcd=False, ttbar=False, data=False, all_signal=not settings.run_n_tk_seeds)
+        samples = pick_samples(dataset, qcd=False, ttbar=True, data=False, all_signal=not settings.run_n_tk_seeds)
         
     set_splitting(samples, dataset, 'ntuple', data_json=json_path('ana_2017p8.json'), limit_ttbar=True)
 


### PR DESCRIPTION
Current setup of rp scheme still does not allow for mc background samples to be run over using rp filter, but now you can at least run over background mc samples without issue.