### PR TITLE
Missleading mode=mode[0] (which is event_filter setting) in NtupleCommon.py 

### DIFF
--- a/MFVNeutralino/python/NtupleCommon.py
+++ b/MFVNeutralino/python/NtupleCommon.py
@@ -338,7 +338,7 @@ def miniaod_ntuple_process(settings):
     mods = [
         (prepare_vis,    settings.prepare_vis),
         (run_n_tk_seeds, settings.run_n_tk_seeds),
-        (event_filter,    [settings.event_filter, settings.randpars_filter]),
+        (event_filter,    [settings.mode, settings.randpars_filter]),
         #(event_filter,   settings.event_filter),
         (minitree_only,  settings.minitree_only),
         ]

--- a/MFVNeutralino/test/AlecK0/ntuple.py
+++ b/MFVNeutralino/test/AlecK0/ntuple.py
@@ -4,11 +4,11 @@ settings = NtupleSettings()
 settings.is_mc = True
 settings.is_miniaod = True
 if use_btag_triggers :
-    settings.event_filter = 'bjets OR displaced dijet' # for new trigger studies
+  settings.mode = 'bjets OR displaced dijet' # for new trigger studies
 elif use_MET_triggers :
-  settings.event_filter = 'met only novtx'
+  settings.mode = 'met only novtx'
 else:
-  settings.event_filter = 'jets only novtx'
+  settings.mode = 'jets only novtx'
 
 version = settings.version + 'v2'
 

--- a/MFVNeutralino/test/K0Tracks/ntuple.py
+++ b/MFVNeutralino/test/K0Tracks/ntuple.py
@@ -3,8 +3,8 @@ from JMTucker.MFVNeutralino.NtupleCommon import *
 settings = NtupleSettings()
 settings.is_mc = True
 settings.is_miniaod = True
-#settings.event_filter = 'jets only novtx' Alec commented
-settings.event_filter = 'muons only novtx'
+#settings.mode = 'jets only novtx' Alec commented
+settings.mode = 'muons only novtx'
 
 version = settings.version + 'v1'
 

--- a/MFVNeutralino/test/MT2/ntuple.py
+++ b/MFVNeutralino/test/MT2/ntuple.py
@@ -11,7 +11,7 @@ settings.minitree_only = 2
 settings.prepare_vis = False
 settings.keep_all = False
 settings.keep_gen = False
-settings.event_filter = 'jets only'
+settings.mode = 'jets only'
 
 process = ntuple_process(settings)
 dataset = 'miniaod' if settings.is_miniaod else 'main'

--- a/MFVNeutralino/test/SplitPV/splitpv.py
+++ b/MFVNeutralino/test/SplitPV/splitpv.py
@@ -3,7 +3,7 @@ from JMTucker.MFVNeutralino.NtupleCommon import *
 settings = NtupleSettings()
 settings.is_mc = True
 settings.is_miniaod = True
-settings.event_filter = 'jets only novtx'
+settings.mode = 'jets only novtx'
 
 version = settings.version + 'v3'
 

--- a/MFVNeutralino/test/TrackMover/mctruth.py
+++ b/MFVNeutralino/test/TrackMover/mctruth.py
@@ -5,9 +5,9 @@ from JMTucker.MFVNeutralino.NtupleCommon import *
 settings = NtupleSettings()
 settings.is_mc = True
 settings.is_miniaod = True
-#settings.event_filter = 'electrons only novtx'
-settings.event_filter = 'muons only novtx' #FIXME miss leading because there is no process.mfvEventFilterSequence applied nor signals_no_event_filter_modifier  
-#settings.event_filter = 'bjets OR displaced dijet novtx'
+#settings.mode = 'electrons only novtx'
+settings.mode = 'muons only novtx' #FIXME miss leading because there is no process.mfvEventFilterSequence applied nor signals_no_event_filter_modifier  
+#settings.mode = 'bjets OR displaced dijet novtx'
 version = settings.version + 'v6'
 
 process = ntuple_process(settings)

--- a/MFVNeutralino/test/TrackMover/ntuple.py
+++ b/MFVNeutralino/test/TrackMover/ntuple.py
@@ -6,9 +6,9 @@ from JMTucker.MFVNeutralino.NtupleCommon import *
 settings = NtupleSettings()
 settings.is_mc = False
 settings.is_miniaod = True
-#settings.event_filter= 'electrons only novtx'
-settings.event_filter = 'muons only novtx'
-#settings.event_filter = 'bjets OR displaced dijet novtx'
+#settings.mode= 'electrons only novtx'
+settings.mode = 'muons only novtx'
+#settings.mode = 'bjets OR displaced dijet novtx'
 
 version = settings.version + 'v8' #v8 : [2,0], v9 : [0,2], v10 : [3,2]
 

--- a/MFVNeutralino/test/TrackMoverHighEta/mctruth.py
+++ b/MFVNeutralino/test/TrackMoverHighEta/mctruth.py
@@ -5,9 +5,9 @@ from JMTucker.MFVNeutralino.NtupleCommon import *
 settings = NtupleSettings()
 settings.is_mc = True
 settings.is_miniaod = True
-#settings.event_filter = 'electrons only novtx'
-settings.event_filter = 'muons only novtx' #FIXME miss leading because there is no process.mfvEventFilterSequence applied nor signals_no_event_filter_modifier  
-#settings.event_filter = 'bjets OR displaced dijet novtx'
+#settings.mode = 'electrons only novtx'
+settings.mode = 'muons only novtx' #FIXME miss leading because there is no process.mfvEventFilterSequence applied nor signals_no_event_filter_modifier  
+#settings.mode = 'bjets OR displaced dijet novtx'
 version = settings.version + 'v6'
 
 process = ntuple_process(settings)
@@ -61,7 +61,7 @@ if __name__ == '__main__' and hasattr(sys, 'argv') and 'submit' in sys.argv:
     
     #samples = [getattr(Samples, 'ZHToSSTodddd_tau300um_M55_2018')] 
     #samples = [getattr(Samples, 'mfv_stopdbardbar_tau001000um_M0800_2017')] 
-    #samples = [getattr(Samples, 'WminusHToSSTodddd_tau300um_M55_2018')]
+    #samples = [getattr(Samples, 'WminusHToSSTodddd_tau300um_M55_2017')]
     set_splitting(samples, dataset, 'ntuple')
     ms = MetaSubmitter('TrackMoverMCTruth' + version, dataset=dataset)
     ms.common.pset_modifier = chain_modifiers(is_mc_modifier, era_modifier, per_sample_pileup_weights_modifier())

--- a/MFVNeutralino/test/TrackMoverHighEta/ntuple.py
+++ b/MFVNeutralino/test/TrackMoverHighEta/ntuple.py
@@ -6,9 +6,9 @@ from JMTucker.MFVNeutralino.NtupleCommon import *
 settings = NtupleSettings()
 settings.is_mc = False
 settings.is_miniaod = True
-#settings.event_filter= 'electrons only novtx'
-settings.event_filter = 'muons only novtx'
-#settings.event_filter = 'bjets OR displaced dijet novtx'
+#settings.mode= 'electrons only novtx'
+settings.mode = 'muons only novtx'
+#settings.mode = 'bjets OR displaced dijet novtx'
 
 version = settings.version + 'v8' #v8 : [2,0], v9 : [0,2], v10 : [3,2]
 
@@ -38,10 +38,10 @@ cfgs = named_product(njets = [2], #FIXME
 process = ntuple_process(settings)
 #tfileservice(process, '/uscms/home/pkotamni/nobackup/crabdirs/movedtree.root')
 tfileservice(process, 'movedtree.root')
-#max_events(process, 100)
+max_events(process, 100)
 dataset = 'miniaod' if settings.is_miniaod else 'main'
 #input_files(process, '/store/data/Run2016B/BTagCSV/MINIAOD/21Feb2020_ver2_UL2016_HIPM-v1/240000/FEBA5DAA-3D1A-384D-91EB-A10EF4E504F5.root')
-#input_files(process, '/store/mc/RunIISummer20UL17MiniAODv2/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v2/120001/A8C3978F-4BE4-A844-BEE8-8DEE129A02B7.root')
+input_files(process, '/store/mc/RunIISummer20UL17MiniAODv2/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v2/120001/A8C3978F-4BE4-A844-BEE8-8DEE129A02B7.root')
 #input_files(process, '/store/mc/RunIISummer20UL16MiniAODAPVv2/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v1/2540000/00AF8175-C641-344B-8777-F62041FD6308.root')
 #input_files(process, '/store/mc/RunIISummer20UL17MiniAODv2/WJetsToLNu_2J_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v1/100000/177D06A8-D7E8-E14A-8FB8-E638820EDFF3.root')
 #input_files(process, '/store/mc/RunIISummer20UL17MiniAODv2/WJetsToLNu_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v2/110000/01DA55E6-2A8C-AE48-B2C4-A3DC37E2052D.root')

--- a/MFVNeutralino/test/TrackMoverLowEta/mctruth.py
+++ b/MFVNeutralino/test/TrackMoverLowEta/mctruth.py
@@ -5,9 +5,9 @@ from JMTucker.MFVNeutralino.NtupleCommon import *
 settings = NtupleSettings()
 settings.is_mc = True
 settings.is_miniaod = True
-#settings.event_filter = 'electrons only novtx'
-settings.event_filter = 'muons only novtx' #FIXME miss leading because there is no process.mfvEventFilterSequence applied nor signals_no_event_filter_modifier  
-#settings.event_filter = 'bjets OR displaced dijet novtx'
+#settings.mode = 'electrons only novtx'
+settings.mode = 'muons only novtx' #FIXME miss leading because there is no process.mfvEventFilterSequence applied nor signals_no_event_filter_modifier  
+#settings.mode = 'bjets OR displaced dijet novtx'
 version = settings.version + 'v6'
 
 process = ntuple_process(settings)
@@ -61,7 +61,7 @@ if __name__ == '__main__' and hasattr(sys, 'argv') and 'submit' in sys.argv:
     
     #samples = [getattr(Samples, 'ZHToSSTodddd_tau300um_M55_2018')] 
     #samples = [getattr(Samples, 'mfv_stopdbardbar_tau001000um_M0800_2017')] 
-    #samples = [getattr(Samples, 'WminusHToSSTodddd_tau300um_M55_2018')]
+    #samples = [getattr(Samples, 'WminusHToSSTodddd_tau300um_M55_2017')]
     set_splitting(samples, dataset, 'ntuple')
     ms = MetaSubmitter('TrackMoverMCTruth' + version, dataset=dataset)
     ms.common.pset_modifier = chain_modifiers(is_mc_modifier, era_modifier, per_sample_pileup_weights_modifier())

--- a/MFVNeutralino/test/TrackMoverLowEta/ntuple.py
+++ b/MFVNeutralino/test/TrackMoverLowEta/ntuple.py
@@ -6,9 +6,9 @@ from JMTucker.MFVNeutralino.NtupleCommon import *
 settings = NtupleSettings()
 settings.is_mc = False
 settings.is_miniaod = True
-#settings.event_filter= 'electrons only novtx'
-settings.event_filter = 'muons only novtx'
-#settings.event_filter = 'bjets OR displaced dijet novtx'
+#settings.mode= 'electrons only novtx'
+settings.mode = 'muons only novtx'
+#settings.mode = 'bjets OR displaced dijet novtx'
 
 version = settings.version + 'v8' #v8 : [2,0], v9 : [0,2], v10 : [3,2]
 
@@ -38,10 +38,10 @@ cfgs = named_product(njets = [2], #FIXME
 process = ntuple_process(settings)
 #tfileservice(process, '/uscms/home/pkotamni/nobackup/crabdirs/movedtree.root')
 tfileservice(process, 'movedtree.root')
-#max_events(process, 100)
+max_events(process, 100)
 dataset = 'miniaod' if settings.is_miniaod else 'main'
 #input_files(process, '/store/data/Run2016B/BTagCSV/MINIAOD/21Feb2020_ver2_UL2016_HIPM-v1/240000/FEBA5DAA-3D1A-384D-91EB-A10EF4E504F5.root')
-#input_files(process, '/store/mc/RunIISummer20UL17MiniAODv2/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v2/120001/A8C3978F-4BE4-A844-BEE8-8DEE129A02B7.root')
+input_files(process, '/store/mc/RunIISummer20UL17MiniAODv2/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v2/120001/A8C3978F-4BE4-A844-BEE8-8DEE129A02B7.root')
 #input_files(process, '/store/mc/RunIISummer20UL16MiniAODAPVv2/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v1/2540000/00AF8175-C641-344B-8777-F62041FD6308.root')
 #input_files(process, '/store/mc/RunIISummer20UL17MiniAODv2/WJetsToLNu_2J_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v1/100000/177D06A8-D7E8-E14A-8FB8-E638820EDFF3.root')
 #input_files(process, '/store/mc/RunIISummer20UL17MiniAODv2/WJetsToLNu_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v2/110000/01DA55E6-2A8C-AE48-B2C4-A3DC37E2052D.root')

--- a/MFVNeutralino/test/TrackMoverMixEta/mctruth.py
+++ b/MFVNeutralino/test/TrackMoverMixEta/mctruth.py
@@ -5,9 +5,9 @@ from JMTucker.MFVNeutralino.NtupleCommon import *
 settings = NtupleSettings()
 settings.is_mc = True
 settings.is_miniaod = True
-#settings.event_filter = 'electrons only novtx'
-settings.event_filter = 'muons only novtx' #FIXME miss leading because there is no process.mfvEventFilterSequence applied nor signals_no_event_filter_modifier  
-#settings.event_filter = 'bjets OR displaced dijet novtx'
+#settings.mode = 'electrons only novtx'
+settings.mode = 'muons only novtx' #FIXME miss leading because there is no process.mfvEventFilterSequence applied nor signals_no_event_filter_modifier  
+#settings.mode = 'bjets OR displaced dijet novtx'
 version = settings.version + 'v6'
 
 process = ntuple_process(settings)
@@ -61,7 +61,7 @@ if __name__ == '__main__' and hasattr(sys, 'argv') and 'submit' in sys.argv:
     
     #samples = [getattr(Samples, 'ZHToSSTodddd_tau300um_M55_2018')] 
     #samples = [getattr(Samples, 'mfv_stopdbardbar_tau001000um_M0800_2017')] 
-    #samples = [getattr(Samples, 'WminusHToSSTodddd_tau300um_M55_2018')]
+    #samples = [getattr(Samples, 'WminusHToSSTodddd_tau300um_M55_2017')]
     set_splitting(samples, dataset, 'ntuple')
     ms = MetaSubmitter('TrackMoverMCTruth' + version, dataset=dataset)
     ms.common.pset_modifier = chain_modifiers(is_mc_modifier, era_modifier, per_sample_pileup_weights_modifier())

--- a/MFVNeutralino/test/TrackMoverMixEta/ntuple.py
+++ b/MFVNeutralino/test/TrackMoverMixEta/ntuple.py
@@ -6,9 +6,9 @@ from JMTucker.MFVNeutralino.NtupleCommon import *
 settings = NtupleSettings()
 settings.is_mc = False
 settings.is_miniaod = True
-#settings.event_filter= 'electrons only novtx'
-settings.event_filter = 'muons only novtx'
-#settings.event_filter = 'bjets OR displaced dijet novtx'
+#settings.mode= 'electrons only novtx'
+settings.mode = 'muons only novtx'
+#settings.mode = 'bjets OR displaced dijet novtx'
 
 version = settings.version + 'v8' #v8 : [2,0], v9 : [0,2], v10 : [3,2]
 
@@ -38,10 +38,10 @@ cfgs = named_product(njets = [2], #FIXME
 process = ntuple_process(settings)
 #tfileservice(process, '/uscms/home/pkotamni/nobackup/crabdirs/movedtree.root')
 tfileservice(process, 'movedtree.root')
-#max_events(process, 100)
+max_events(process, 100)
 dataset = 'miniaod' if settings.is_miniaod else 'main'
 #input_files(process, '/store/data/Run2016B/BTagCSV/MINIAOD/21Feb2020_ver2_UL2016_HIPM-v1/240000/FEBA5DAA-3D1A-384D-91EB-A10EF4E504F5.root')
-#input_files(process, '/store/mc/RunIISummer20UL17MiniAODv2/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v2/120001/A8C3978F-4BE4-A844-BEE8-8DEE129A02B7.root')
+input_files(process, '/store/mc/RunIISummer20UL17MiniAODv2/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v2/120001/A8C3978F-4BE4-A844-BEE8-8DEE129A02B7.root')
 #input_files(process, '/store/mc/RunIISummer20UL16MiniAODAPVv2/TTJets_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/106X_mcRun2_asymptotic_preVFP_v11-v1/2540000/00AF8175-C641-344B-8777-F62041FD6308.root')
 #input_files(process, '/store/mc/RunIISummer20UL17MiniAODv2/WJetsToLNu_2J_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v1/100000/177D06A8-D7E8-E14A-8FB8-E638820EDFF3.root')
 #input_files(process, '/store/mc/RunIISummer20UL17MiniAODv2/WJetsToLNu_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/106X_mc2017_realistic_v9-v2/110000/01DA55E6-2A8C-AE48-B2C4-A3DC37E2052D.root')

--- a/MFVNeutralino/test/ntuple.py
+++ b/MFVNeutralino/test/ntuple.py
@@ -14,12 +14,12 @@ settings.keep_all = False #FIXME
 settings.keep_gen = False
 settings.keep_tk = False
 if use_btag_triggers :
-    #settings.event_filter = 'dilepton only' # for new trigger studies
-    #settings.event_filter = 'leptons only' # for new trigger studies
-    #settings.event_filter = 'low HT online track test' # for new trigger studies
+    #settings.mode = 'dilepton only' # for new trigger studies
+    #settings.mode = 'leptons only' # for new trigger studies
+    #settings.mode = 'low HT online track test' # for new trigger studies
     settings.mode = 'bjets OR displaced dijet' # for new trigger studies
 elif use_MET_triggers :
-    #settings.event_filter = 'met only'
+    #settings.mode = 'met only'
     settings.mode = 'met only'
     #settings.mode = 'met AND iso muons'
 elif use_Muon_triggers :


### PR DESCRIPTION
issue : a specific mode such as "MET AND iso muons" was failed to be set in [EventFilter.py](https://github.com/DisplacedVertices/cmssw-usercode/blob/UL_Lepton/MFVNeutralino/python/EventFilter.py#L67) because NtupleCommon.py sets mode=mode[0] and [mode[0] is set by settings.event_filter](https://github.com/DisplacedVertices/cmssw-usercode/blob/UL_Lepton/MFVNeutralino/python/NtupleCommon.py#L341) 
solution : unify all places in the source code with settings.event_filter and replace it by settings.mode