### PR TITLE
Added the ggZH samples after querying DAS

### DIFF
--- a/Tools/python/Samples.py
+++ b/Tools/python/Samples.py
@@ -544,7 +544,7 @@ ggZHToSSTobbbb_samples_20161 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau10mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau30mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
-    #MCSample('ggZHToSSTobbbb_tau100mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     #MCSample('ggZHToSSTobbbb_tau300mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24998),
     #MCSample('ggZHToSSTobbbb_tau1000mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
 
@@ -557,7 +557,7 @@ ggZHToSSTobbbb_samples_20161 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau10mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
     MCSample('ggZHToSSTobbbb_tau30mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
-    #MCSample('ggZHToSSTobbbb_tau100mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     #MCSample('ggZHToSSTobbbb_tau300mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24156),
     #MCSample('ggZHToSSTobbbb_tau1000mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
 
@@ -570,7 +570,7 @@ ggZHToSSTobbbb_samples_20161 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau10mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
     MCSample('ggZHToSSTobbbb_tau30mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
-    #MCSample('ggZHToSSTobbbb_tau100mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     #MCSample('ggZHToSSTobbbb_tau300mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24154),
     #MCSample('ggZHToSSTobbbb_tau1000mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
 ]
@@ -585,7 +585,7 @@ ggZHToSSTodddd_samples_20161 = [
     MCSample('ggZHToSSTodddd_tau3mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau10mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau30mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
-    #MCSample('ggZHToSSTodddd_tau100mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau100mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     #MCSample('ggZHToSSTodddd_tau300mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24143),
     #MCSample('ggZHToSSTodddd_tau1000mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
 
@@ -598,7 +598,7 @@ ggZHToSSTodddd_samples_20161 = [
     MCSample('ggZHToSSTodddd_tau3mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau10mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
     MCSample('ggZHToSSTodddd_tau30mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
-    #MCSample('ggZHToSSTodddd_tau100mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau100mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     #MCSample('ggZHToSSTodddd_tau300mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     #MCSample('ggZHToSSTodddd_tau1000mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
 
@@ -611,7 +611,7 @@ ggZHToSSTodddd_samples_20161 = [
     MCSample('ggZHToSSTodddd_tau3mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau10mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
     MCSample('ggZHToSSTodddd_tau30mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
-    #MCSample('ggZHToSSTodddd_tau100mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau100mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     #MCSample('ggZHToSSTodddd_tau300mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
     #MCSample('ggZHToSSTodddd_tau1000mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
 ]
@@ -1062,7 +1062,7 @@ ggZHToSSTobbbb_samples_20162 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau10mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau30mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
-    #MCSample('ggZHToSSTobbbb_tau100mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     #MCSample('ggZHToSSTobbbb_tau300mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24152),
     #MCSample('ggZHToSSTobbbb_tau1000mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
 
@@ -1075,7 +1075,7 @@ ggZHToSSTobbbb_samples_20162 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau10mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau30mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
-    #MCSample('ggZHToSSTobbbb_tau100mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24153),
+    MCSample('ggZHToSSTobbbb_tau100mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24153),
     #MCSample('ggZHToSSTobbbb_tau300mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     #MCSample('ggZHToSSTobbbb_tau1000mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
 
@@ -1088,7 +1088,7 @@ ggZHToSSTobbbb_samples_20162 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24998),
     MCSample('ggZHToSSTobbbb_tau10mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau30mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24997),
-    #MCSample('ggZHToSSTobbbb_tau100mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24999),
+    MCSample('ggZHToSSTobbbb_tau100mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24999),
     #MCSample('ggZHToSSTobbbb_tau300mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24997),
     #MCSample('ggZHToSSTobbbb_tau1000mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
 ]
@@ -1103,7 +1103,7 @@ ggZHToSSTodddd_samples_20162 = [
     MCSample('ggZHToSSTodddd_tau3mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau10mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau30mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
-    #MCSample('ggZHToSSTodddd_tau100mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau100mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     #MCSample('ggZHToSSTodddd_tau300mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     #MCSample('ggZHToSSTodddd_tau1000mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
 
@@ -1116,7 +1116,7 @@ ggZHToSSTodddd_samples_20162 = [
     MCSample('ggZHToSSTodddd_tau3mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau10mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau30mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
-    #MCSample('ggZHToSSTodddd_tau100mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau100mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     #MCSample('ggZHToSSTodddd_tau300mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     #MCSample('ggZHToSSTodddd_tau1000mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
 
@@ -1129,7 +1129,7 @@ ggZHToSSTodddd_samples_20162 = [
     MCSample('ggZHToSSTodddd_tau3mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau10mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau30mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
-    #MCSample('ggZHToSSTodddd_tau100mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24998),
+    MCSample('ggZHToSSTodddd_tau100mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24998),
     #MCSample('ggZHToSSTodddd_tau300mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24999),
     #MCSample('ggZHToSSTodddd_tau1000mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
 ]
@@ -1686,7 +1686,7 @@ ggZHToSSTobbbb_samples_2017 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau10mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau30mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
-    #MCSample('ggZHToSSTobbbb_tau100mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     #MCSample('ggZHToSSTobbbb_tau300mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     #MCSample('ggZHToSSTobbbb_tau1000mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
 
@@ -1699,7 +1699,7 @@ ggZHToSSTobbbb_samples_2017 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau10mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau30mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
-    #MCSample('ggZHToSSTobbbb_tau100mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     #MCSample('ggZHToSSTobbbb_tau300mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     #MCSample('ggZHToSSTobbbb_tau1000mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
 
@@ -1712,7 +1712,7 @@ ggZHToSSTobbbb_samples_2017 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau10mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49999),
     MCSample('ggZHToSSTobbbb_tau30mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49999),
-    #MCSample('ggZHToSSTobbbb_tau100mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     #MCSample('ggZHToSSTobbbb_tau300mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 48999),
     #MCSample('ggZHToSSTobbbb_tau1000mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49000),
 ]
@@ -1727,7 +1727,7 @@ ggZHToSSTodddd_samples_2017 = [
     MCSample('ggZHToSSTodddd_tau3mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTodddd_tau10mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTodddd_tau30mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
-    #MCSample('ggZHToSSTodddd_tau100mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau100mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     #MCSample('ggZHToSSTodddd_tau300mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49000),
     #MCSample('ggZHToSSTodddd_tau1000mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
 
@@ -1740,7 +1740,7 @@ ggZHToSSTodddd_samples_2017 = [
     MCSample('ggZHToSSTodddd_tau3mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49000),
     MCSample('ggZHToSSTodddd_tau10mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTodddd_tau30mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
-    #MCSample('ggZHToSSTodddd_tau100mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau100mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     #MCSample('ggZHToSSTodddd_tau300mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     #MCSample('ggZHToSSTodddd_tau1000mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
 
@@ -1753,7 +1753,7 @@ ggZHToSSTodddd_samples_2017 = [
     MCSample('ggZHToSSTodddd_tau3mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49998),
     MCSample('ggZHToSSTodddd_tau10mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49998),
     MCSample('ggZHToSSTodddd_tau30mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49996),
-    #MCSample('ggZHToSSTodddd_tau100mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau100mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     #MCSample('ggZHToSSTodddd_tau300mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49997),
     #MCSample('ggZHToSSTodddd_tau1000mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49999),
 ]
@@ -2246,7 +2246,7 @@ ggZHToSSTobbbb_samples_2018 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau10mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau30mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
-    #MCSample('ggZHToSSTobbbb_tau100mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     #MCSample('ggZHToSSTobbbb_tau300mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     #MCSample('ggZHToSSTobbbb_tau1000mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
 
@@ -2259,7 +2259,7 @@ ggZHToSSTobbbb_samples_2018 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau10mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau30mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 48000),
-    #MCSample('ggZHToSSTobbbb_tau100mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     #MCSample('ggZHToSSTobbbb_tau300mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 48000),
     #MCSample('ggZHToSSTobbbb_tau1000mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
 
@@ -2272,7 +2272,7 @@ ggZHToSSTobbbb_samples_2018 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 48998),
     MCSample('ggZHToSSTobbbb_tau10mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
     MCSample('ggZHToSSTobbbb_tau30mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
-    #MCSample('ggZHToSSTobbbb_tau100mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49998),
+    MCSample('ggZHToSSTobbbb_tau100mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49998),
     #MCSample('ggZHToSSTobbbb_tau300mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
     #MCSample('ggZHToSSTobbbb_tau1000mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
 ]
@@ -2287,7 +2287,7 @@ ggZHToSSTodddd_samples_2018 = [
     MCSample('ggZHToSSTodddd_tau3mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTodddd_tau10mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTodddd_tau30mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
-    #MCSample('ggZHToSSTodddd_tau100mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49000),
+    MCSample('ggZHToSSTodddd_tau100mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49000),
     #MCSample('ggZHToSSTodddd_tau300mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     #MCSample('ggZHToSSTodddd_tau1000mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
 
@@ -2300,7 +2300,7 @@ ggZHToSSTodddd_samples_2018 = [
     MCSample('ggZHToSSTodddd_tau3mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49000),
     MCSample('ggZHToSSTodddd_tau10mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49000),
     MCSample('ggZHToSSTodddd_tau30mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
-    #MCSample('ggZHToSSTodddd_tau100mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau100mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     #MCSample('ggZHToSSTodddd_tau300mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49000),
     #MCSample('ggZHToSSTodddd_tau1000mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
 
@@ -2313,7 +2313,7 @@ ggZHToSSTodddd_samples_2018 = [
     MCSample('ggZHToSSTodddd_tau3mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTodddd_tau10mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49998),
     MCSample('ggZHToSSTodddd_tau30mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 48999),
-    #MCSample('ggZHToSSTodddd_tau100mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTodddd_tau100mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
     #MCSample('ggZHToSSTodddd_tau300mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 47999),
     #MCSample('ggZHToSSTodddd_tau1000mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
 ]

--- a/Tools/python/Samples.py
+++ b/Tools/python/Samples.py
@@ -53,6 +53,8 @@ def _decay(sample):
         'ggHToSSTodddd' : r'ggH \rightarrow SS \rightarrow d\bar{d}d\bar{d}',
         'ggHToSSTo4l' : r'ggH \rightarrow SS \rightarrow llll',
         'ZHToSSTodddd' : r'ZH \rightarrow SS \rightarrow d\bar{d}d\bar{d}',
+        'ggZHToSSTobbbb' : r'ggZH \rightarrow SS \rightarrow b\bar{b}b\bar{b}',
+        'ggZHToSSTodddd' : r'ggZH \rightarrow SS \rightarrow d\bar{d}d\bar{d}',
         'WplusHToSSTodddd' : r'W^{\plus}H \rightarrow SS \rightarrow d\bar{d}d\bar{d}',
         'WminusHToSSTodddd' : r'W^{\minus}H \rightarrow SS \rightarrow d\bar{d}d\bar{d}',
         'ttHToLLPs_bbbb': r't\bar{t}H \rightarrow SS \rightarrow b\bar{b}b\bar{b}',
@@ -85,8 +87,10 @@ def _set_signal_stuff(sample):
         sample.xsec = 3*(9.426e-02)*br_h_llps# Higgs 125, once for each lepton flavor - https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageAt13TeV#WHlH_l_e_or_Process
     elif (sample.name.startswith('WminusH')):
         sample.xsec = 3*(5.983e-02)*br_h_llps# same reasoning as above
+    elif (sample.name.startswith('ggZH')):
+        sample.xsec = 3*(4.14e-03)*br_h_llps# gg-initiated ZH, MH=125 - https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageAt13TeV#ZH_Process
     elif (sample.name.startswith('ZH')):
-        sample.xsec = 3*(2.982e-02)*br_h_llps# same reasoning as above
+        sample.xsec = 3*(2.568e-02)*br_h_llps# qq-initiated ZH (total ZH 2.982e-02 minus gg component 4.14e-03), MH=125
     elif sample.name.startswith('ttHToLLPs'):
         sample.xsec = 0.5071 * br_h_llps # Higgs 125 - https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageAt13TeV?u#ttH_Process
     else:
@@ -530,8 +534,90 @@ ttHToLLPs_dddd_samples_20161 = [
     MCSample('ttHToLLPs_dddd_tau10mm_M55_20161', '/ttHToLLPs_dddd_tau10mm_M55_20161/None/USER', 149015),
 ]
 
+ggZHToSSTobbbb_samples_20161 = [
+    MCSample('ggZHToSSTobbbb_tau0um_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau10um_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau30um_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau100um_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau300um_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau1mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau3mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau10mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau30mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau300mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24998),
+    MCSample('ggZHToSSTobbbb_tau1000mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+
+    MCSample('ggZHToSSTobbbb_tau0um_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau10um_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24155),
+    MCSample('ggZHToSSTobbbb_tau30um_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau100um_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau300um_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
+    MCSample('ggZHToSSTobbbb_tau1mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau3mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau10mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
+    MCSample('ggZHToSSTobbbb_tau30mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau300mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24156),
+    MCSample('ggZHToSSTobbbb_tau1000mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+
+    MCSample('ggZHToSSTobbbb_tau0um_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24155),
+    MCSample('ggZHToSSTobbbb_tau10um_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau30um_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24155),
+    MCSample('ggZHToSSTobbbb_tau100um_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau300um_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau1mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau3mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau10mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
+    MCSample('ggZHToSSTobbbb_tau30mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau300mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24154),
+    MCSample('ggZHToSSTobbbb_tau1000mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
+]
+
+ggZHToSSTodddd_samples_20161 = [
+    MCSample('ggZHToSSTodddd_tau0um_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau10um_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau30um_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau100um_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau300um_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau1mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau3mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau10mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau30mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau100mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau300mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24143),
+    MCSample('ggZHToSSTodddd_tau1000mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+
+    MCSample('ggZHToSSTodddd_tau0um_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau10um_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau30um_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24184),
+    MCSample('ggZHToSSTodddd_tau100um_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau300um_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau1mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau3mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau10mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
+    MCSample('ggZHToSSTodddd_tau30mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau100mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau300mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau1000mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+
+    MCSample('ggZHToSSTodddd_tau0um_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau10um_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24997),
+    MCSample('ggZHToSSTodddd_tau30um_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau100um_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau300um_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau1mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24998),
+    MCSample('ggZHToSSTodddd_tau3mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau10mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
+    MCSample('ggZHToSSTodddd_tau30mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
+    MCSample('ggZHToSSTodddd_tau100mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau300mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
+    MCSample('ggZHToSSTodddd_tau1000mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
+]
+
 all_bjet_signal_samples_20161 = mfv_signal_samples_20161 + mfv_stopdbardbar_samples_20161 + mfv_stopbbarbbar_samples_20161 + ggHToSSTodddd_samples_20161 + ttHToLLPs_bbbb_samples_20161 + ttHToLLPs_dddd_samples_20161
-all_lep_signal_samples_20161  = ZHToSSTodddd_samples_20161 + WplusHToSSTodddd_samples_20161 + WminusHToSSTodddd_samples_20161 + ttHToLLPs_bbbb_samples_20161 + ttHToLLPs_dddd_samples_20161
+all_lep_signal_samples_20161  = ZHToSSTodddd_samples_20161 + WplusHToSSTodddd_samples_20161 + WminusHToSSTodddd_samples_20161 + ttHToLLPs_bbbb_samples_20161 + ttHToLLPs_dddd_samples_20161 + ggZHToSSTobbbb_samples_20161 + ggZHToSSTodddd_samples_20161
 all_signal_samples_20161 = all_bjet_signal_samples_20161 + all_lep_signal_samples_20161
 
 #######
@@ -966,8 +1052,90 @@ ttHToLLPs_dddd_samples_20162 = [
     MCSample('ttHToLLPs_dddd_tau10mm_M55_20162', '/ttHToLLPs_dddd_tau10mm_M55_20162/None/USER', 148886),
 ]
 
+ggZHToSSTobbbb_samples_20162 = [
+    MCSample('ggZHToSSTobbbb_tau0um_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau10um_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau30um_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau100um_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau300um_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau1mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau3mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau10mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau30mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau300mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24152),
+    MCSample('ggZHToSSTobbbb_tau1000mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+
+    MCSample('ggZHToSSTobbbb_tau0um_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau10um_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau30um_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau100um_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau300um_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau1mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau3mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau10mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau30mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24153),
+    MCSample('ggZHToSSTobbbb_tau300mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau1000mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+
+    MCSample('ggZHToSSTobbbb_tau0um_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau10um_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24122),
+    MCSample('ggZHToSSTobbbb_tau30um_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24999),
+    MCSample('ggZHToSSTobbbb_tau100um_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24999),
+    MCSample('ggZHToSSTobbbb_tau300um_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau1mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24998),
+    MCSample('ggZHToSSTobbbb_tau3mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24998),
+    MCSample('ggZHToSSTobbbb_tau10mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTobbbb_tau30mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24997),
+    MCSample('ggZHToSSTobbbb_tau100mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24999),
+    MCSample('ggZHToSSTobbbb_tau300mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24997),
+    MCSample('ggZHToSSTobbbb_tau1000mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+]
+
+ggZHToSSTodddd_samples_20162 = [
+    MCSample('ggZHToSSTodddd_tau0um_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau10um_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau30um_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau100um_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau300um_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau1mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24152),
+    MCSample('ggZHToSSTodddd_tau3mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau10mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau30mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau100mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau300mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau1000mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+
+    MCSample('ggZHToSSTodddd_tau0um_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau10um_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24141),
+    MCSample('ggZHToSSTodddd_tau30um_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau100um_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau300um_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24999),
+    MCSample('ggZHToSSTodddd_tau1mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau3mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau10mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau30mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau100mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau300mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau1000mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+
+    MCSample('ggZHToSSTodddd_tau0um_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau10um_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau30um_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24998),
+    MCSample('ggZHToSSTodddd_tau100um_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24997),
+    MCSample('ggZHToSSTodddd_tau300um_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau1mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24132),
+    MCSample('ggZHToSSTodddd_tau3mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau10mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau30mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    MCSample('ggZHToSSTodddd_tau100mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24998),
+    MCSample('ggZHToSSTodddd_tau300mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24999),
+    MCSample('ggZHToSSTodddd_tau1000mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+]
+
 all_bjet_signal_samples_20162 = mfv_signal_samples_20162 + mfv_stopdbardbar_samples_20162 + mfv_stopbbarbbar_samples_20162 + ggHToSSTodddd_samples_20162 + ttHToLLPs_bbbb_samples_20162 + ttHToLLPs_dddd_samples_20162
-all_lep_signal_samples_20162  = ZHToSSTodddd_samples_20162 + WplusHToSSTodddd_samples_20162 + WminusHToSSTodddd_samples_20162 + ttHToLLPs_bbbb_samples_20162 + ttHToLLPs_dddd_samples_20162
+all_lep_signal_samples_20162  = ZHToSSTodddd_samples_20162 + WplusHToSSTodddd_samples_20162 + WminusHToSSTodddd_samples_20162 + ttHToLLPs_bbbb_samples_20162 + ttHToLLPs_dddd_samples_20162 + ggZHToSSTobbbb_samples_20162 + ggZHToSSTodddd_samples_20162
 all_signal_samples_20162 = all_bjet_signal_samples_20162 + all_lep_signal_samples_20162
 
 ########
@@ -1508,8 +1676,90 @@ ttHToLLPs_dddd_samples_2017 = [
     MCSample('ttHToLLPs_dddd_tau10mm_M55_2017', '/ttHToLLPs_dddd_tau10mm_M55_2017/None/USER', 223329),
 ]
 
+ggZHToSSTobbbb_samples_2017 = [
+    MCSample('ggZHToSSTobbbb_tau0um_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau10um_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau30um_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau100um_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49000),
+    MCSample('ggZHToSSTobbbb_tau300um_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau1mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau3mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau10mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau30mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau300mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau1000mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+
+    MCSample('ggZHToSSTobbbb_tau0um_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau10um_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau30um_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau100um_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau300um_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau1mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTobbbb_tau3mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau10mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau30mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau300mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau1000mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+
+    MCSample('ggZHToSSTobbbb_tau0um_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau10um_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTobbbb_tau30um_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTobbbb_tau100um_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49998),
+    MCSample('ggZHToSSTobbbb_tau300um_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49998),
+    MCSample('ggZHToSSTobbbb_tau1mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49998),
+    MCSample('ggZHToSSTobbbb_tau3mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau10mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTobbbb_tau30mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTobbbb_tau100mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau300mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 48999),
+    MCSample('ggZHToSSTobbbb_tau1000mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49000),
+]
+
+ggZHToSSTodddd_samples_2017 = [
+    MCSample('ggZHToSSTodddd_tau0um_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau10um_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau30um_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau100um_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau300um_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 48000),
+    MCSample('ggZHToSSTodddd_tau1mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau3mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau10mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau30mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau100mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau300mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49000),
+    MCSample('ggZHToSSTodddd_tau1000mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+
+    MCSample('ggZHToSSTodddd_tau0um_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau10um_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau30um_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTodddd_tau100um_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau300um_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau1mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau3mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49000),
+    MCSample('ggZHToSSTodddd_tau10mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau30mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau100mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau300mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau1000mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+
+    MCSample('ggZHToSSTodddd_tau0um_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 48998),
+    MCSample('ggZHToSSTodddd_tau10um_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau30um_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49997),
+    MCSample('ggZHToSSTodddd_tau100um_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau300um_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49998),
+    MCSample('ggZHToSSTodddd_tau1mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49997),
+    MCSample('ggZHToSSTodddd_tau3mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49998),
+    MCSample('ggZHToSSTodddd_tau10mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49998),
+    MCSample('ggZHToSSTodddd_tau30mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49996),
+    MCSample('ggZHToSSTodddd_tau100mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau300mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49997),
+    MCSample('ggZHToSSTodddd_tau1000mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49999),
+]
+
 all_bjet_signal_samples_2017 = mfv_signal_samples_2017 + mfv_stopdbardbar_samples_2017 + mfv_stopbbarbbar_samples_2017 + ggHToSSTodddd_samples_2017 + ttHToLLPs_bbbb_samples_2017 + ttHToLLPs_dddd_samples_2017
-all_lep_signal_samples_2017  = ZHToSSTodddd_samples_2017 + WplusHToSSTodddd_samples_2017 + WminusHToSSTodddd_samples_2017 + ttHToLLPs_bbbb_samples_2017 + ttHToLLPs_dddd_samples_2017
+all_lep_signal_samples_2017  = ZHToSSTodddd_samples_2017 + WplusHToSSTodddd_samples_2017 + WminusHToSSTodddd_samples_2017 + ttHToLLPs_bbbb_samples_2017 + ttHToLLPs_dddd_samples_2017 + ggZHToSSTobbbb_samples_2017 + ggZHToSSTodddd_samples_2017
 all_signal_samples_2017 = all_bjet_signal_samples_2017 + all_lep_signal_samples_2017
 
 splitSUSY_samples_2017 = mfv_splitSUSY_samples_2017
@@ -1986,8 +2236,90 @@ ttHToLLPs_dddd_samples_2018 = [
     MCSample('ttHToLLPs_dddd_tau10mm_M55_2018', '/ttHToLLPs_dddd_tau10mm_M55_2018/None/USER', 224736),
 ]
 
+ggZHToSSTobbbb_samples_2018 = [
+    MCSample('ggZHToSSTobbbb_tau0um_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 48000),
+    MCSample('ggZHToSSTobbbb_tau10um_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau30um_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau100um_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau300um_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49000),
+    MCSample('ggZHToSSTobbbb_tau1mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau3mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau10mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau30mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau300mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau1000mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+
+    MCSample('ggZHToSSTobbbb_tau0um_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 48000),
+    MCSample('ggZHToSSTobbbb_tau10um_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau30um_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTobbbb_tau100um_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau300um_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau1mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau3mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau10mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau30mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 48000),
+    MCSample('ggZHToSSTobbbb_tau100mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau300mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 48000),
+    MCSample('ggZHToSSTobbbb_tau1000mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+
+    MCSample('ggZHToSSTobbbb_tau0um_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTobbbb_tau10um_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTobbbb_tau30um_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTobbbb_tau100um_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTobbbb_tau300um_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTobbbb_tau1mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49998),
+    MCSample('ggZHToSSTobbbb_tau3mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 48998),
+    MCSample('ggZHToSSTobbbb_tau10mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTobbbb_tau30mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTobbbb_tau100mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49998),
+    MCSample('ggZHToSSTobbbb_tau300mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTobbbb_tau1000mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+]
+
+ggZHToSSTodddd_samples_2018 = [
+    MCSample('ggZHToSSTodddd_tau0um_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau10um_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau30um_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau100um_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau300um_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau1mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau3mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau10mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau30mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau100mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49000),
+    MCSample('ggZHToSSTodddd_tau300mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau1000mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+
+    MCSample('ggZHToSSTodddd_tau0um_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTodddd_tau10um_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau30um_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTodddd_tau100um_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau300um_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau1mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49000),
+    MCSample('ggZHToSSTodddd_tau3mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49000),
+    MCSample('ggZHToSSTodddd_tau10mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49000),
+    MCSample('ggZHToSSTodddd_tau30mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTodddd_tau100mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau300mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49000),
+    MCSample('ggZHToSSTodddd_tau1000mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+
+    MCSample('ggZHToSSTodddd_tau0um_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49998),
+    MCSample('ggZHToSSTodddd_tau10um_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau30um_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p03_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTodddd_tau100um_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49996),
+    MCSample('ggZHToSSTodddd_tau300um_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau1mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49997),
+    MCSample('ggZHToSSTodddd_tau3mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    MCSample('ggZHToSSTodddd_tau10mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49998),
+    MCSample('ggZHToSSTodddd_tau30mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 48999),
+    MCSample('ggZHToSSTodddd_tau100mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
+    MCSample('ggZHToSSTodddd_tau300mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 47999),
+    MCSample('ggZHToSSTodddd_tau1000mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+]
+
 all_bjet_signal_samples_2018 = mfv_signal_samples_2018 + mfv_stopdbardbar_samples_2018 + mfv_stopbbarbbar_samples_2018 + ggHToSSTodddd_samples_2018 + ttHToLLPs_bbbb_samples_2018 + ttHToLLPs_dddd_samples_2018
-all_lep_signal_samples_2018  = ZHToSSTodddd_samples_2018 + WplusHToSSTodddd_samples_2018 + WminusHToSSTodddd_samples_2018 + ttHToLLPs_bbbb_samples_2018 + ttHToLLPs_dddd_samples_2018
+all_lep_signal_samples_2018  = ZHToSSTodddd_samples_2018 + WplusHToSSTodddd_samples_2018 + WminusHToSSTodddd_samples_2018 + ttHToLLPs_bbbb_samples_2018 + ttHToLLPs_dddd_samples_2018 + ggZHToSSTobbbb_samples_2018 + ggZHToSSTodddd_samples_2018
 all_signal_samples_2018 = all_bjet_signal_samples_2018 + all_lep_signal_samples_2018
 
 ########

--- a/Tools/python/Samples.py
+++ b/Tools/python/Samples.py
@@ -2764,6 +2764,14 @@ for sample in ttHToLLPs_bbbb_samples_2018 + ttHToLLPs_dddd_samples_2018:
     sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
 for sample in ggHToSSTodddd_samples_2018 :
     sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+for sample in ggZHToSSTobbbb_samples_20161 + ggZHToSSTodddd_samples_20161:
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+for sample in ggZHToSSTobbbb_samples_20162 + ggZHToSSTodddd_samples_20162:
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+for sample in ggZHToSSTobbbb_samples_2017 + ggZHToSSTodddd_samples_2017:
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
+for sample in ggZHToSSTobbbb_samples_2018 + ggZHToSSTodddd_samples_2018:
+    sample.add_dataset('miniaod', sample.dataset, sample.nevents_orig)
 
 for s in all_signal_samples_20161: 
     _set_signal_stuff(s)

--- a/Tools/python/Samples.py
+++ b/Tools/python/Samples.py
@@ -544,9 +544,9 @@ ggZHToSSTobbbb_samples_20161 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau10mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau30mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTobbbb_tau100mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTobbbb_tau300mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24998),
-    MCSample('ggZHToSSTobbbb_tau1000mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTobbbb_tau100mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTobbbb_tau300mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24998),
+    #MCSample('ggZHToSSTobbbb_tau1000mm_M15_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
 
     MCSample('ggZHToSSTobbbb_tau0um_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau10um_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24155),
@@ -557,9 +557,9 @@ ggZHToSSTobbbb_samples_20161 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau10mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
     MCSample('ggZHToSSTobbbb_tau30mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTobbbb_tau100mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTobbbb_tau300mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24156),
-    MCSample('ggZHToSSTobbbb_tau1000mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTobbbb_tau100mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTobbbb_tau300mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24156),
+    #MCSample('ggZHToSSTobbbb_tau1000mm_M40_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
 
     MCSample('ggZHToSSTobbbb_tau0um_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24155),
     MCSample('ggZHToSSTobbbb_tau10um_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
@@ -570,9 +570,9 @@ ggZHToSSTobbbb_samples_20161 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau10mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
     MCSample('ggZHToSSTobbbb_tau30mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTobbbb_tau100mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTobbbb_tau300mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24154),
-    MCSample('ggZHToSSTobbbb_tau1000mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
+    #MCSample('ggZHToSSTobbbb_tau100mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTobbbb_tau300mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24154),
+    #MCSample('ggZHToSSTobbbb_tau1000mm_M55_20161', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
 ]
 
 ggZHToSSTodddd_samples_20161 = [
@@ -585,9 +585,9 @@ ggZHToSSTodddd_samples_20161 = [
     MCSample('ggZHToSSTodddd_tau3mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau10mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau30mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTodddd_tau100mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTodddd_tau300mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24143),
-    MCSample('ggZHToSSTodddd_tau1000mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTodddd_tau100mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTodddd_tau300mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24143),
+    #MCSample('ggZHToSSTodddd_tau1000mm_M15_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
 
     MCSample('ggZHToSSTodddd_tau0um_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau10um_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
@@ -598,9 +598,9 @@ ggZHToSSTodddd_samples_20161 = [
     MCSample('ggZHToSSTodddd_tau3mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau10mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
     MCSample('ggZHToSSTodddd_tau30mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTodddd_tau100mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTodddd_tau300mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTodddd_tau1000mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTodddd_tau100mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTodddd_tau300mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTodddd_tau1000mm_M40_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
 
     MCSample('ggZHToSSTodddd_tau0um_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau10um_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24997),
@@ -611,9 +611,9 @@ ggZHToSSTodddd_samples_20161 = [
     MCSample('ggZHToSSTodddd_tau3mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau10mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
     MCSample('ggZHToSSTodddd_tau30mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
-    MCSample('ggZHToSSTodddd_tau100mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTodddd_tau300mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
-    MCSample('ggZHToSSTodddd_tau1000mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
+    #MCSample('ggZHToSSTodddd_tau100mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTodddd_tau300mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
+    #MCSample('ggZHToSSTodddd_tau1000mm_M55_20161', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/MINIAODSIM', 24999),
 ]
 
 all_bjet_signal_samples_20161 = mfv_signal_samples_20161 + mfv_stopdbardbar_samples_20161 + mfv_stopbbarbbar_samples_20161 + ggHToSSTodddd_samples_20161 + ttHToLLPs_bbbb_samples_20161 + ttHToLLPs_dddd_samples_20161
@@ -1062,9 +1062,9 @@ ggZHToSSTobbbb_samples_20162 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau10mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau30mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTobbbb_tau100mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTobbbb_tau300mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24152),
-    MCSample('ggZHToSSTobbbb_tau1000mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTobbbb_tau100mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTobbbb_tau300mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24152),
+    #MCSample('ggZHToSSTobbbb_tau1000mm_M15_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
 
     MCSample('ggZHToSSTobbbb_tau0um_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau10um_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
@@ -1075,9 +1075,9 @@ ggZHToSSTobbbb_samples_20162 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau10mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau30mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTobbbb_tau100mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24153),
-    MCSample('ggZHToSSTobbbb_tau300mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTobbbb_tau1000mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTobbbb_tau100mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24153),
+    #MCSample('ggZHToSSTobbbb_tau300mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTobbbb_tau1000mm_M40_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
 
     MCSample('ggZHToSSTobbbb_tau0um_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau10um_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24122),
@@ -1088,9 +1088,9 @@ ggZHToSSTobbbb_samples_20162 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24998),
     MCSample('ggZHToSSTobbbb_tau10mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTobbbb_tau30mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24997),
-    MCSample('ggZHToSSTobbbb_tau100mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24999),
-    MCSample('ggZHToSSTobbbb_tau300mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24997),
-    MCSample('ggZHToSSTobbbb_tau1000mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTobbbb_tau100mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24999),
+    #MCSample('ggZHToSSTobbbb_tau300mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24997),
+    #MCSample('ggZHToSSTobbbb_tau1000mm_M55_20162', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
 ]
 
 ggZHToSSTodddd_samples_20162 = [
@@ -1103,9 +1103,9 @@ ggZHToSSTodddd_samples_20162 = [
     MCSample('ggZHToSSTodddd_tau3mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau10mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau30mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTodddd_tau100mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTodddd_tau300mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTodddd_tau1000mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTodddd_tau100mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTodddd_tau300mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTodddd_tau1000mm_M15_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
 
     MCSample('ggZHToSSTodddd_tau0um_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau10um_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24141),
@@ -1116,9 +1116,9 @@ ggZHToSSTodddd_samples_20162 = [
     MCSample('ggZHToSSTodddd_tau3mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau10mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau30mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTodddd_tau100mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTodddd_tau300mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTodddd_tau1000mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTodddd_tau100mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTodddd_tau300mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTodddd_tau1000mm_M40_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
 
     MCSample('ggZHToSSTodddd_tau0um_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau10um_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
@@ -1129,9 +1129,9 @@ ggZHToSSTodddd_samples_20162 = [
     MCSample('ggZHToSSTodddd_tau3mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau10mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
     MCSample('ggZHToSSTodddd_tau30mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
-    MCSample('ggZHToSSTodddd_tau100mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24998),
-    MCSample('ggZHToSSTodddd_tau300mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24999),
-    MCSample('ggZHToSSTodddd_tau1000mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
+    #MCSample('ggZHToSSTodddd_tau100mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24998),
+    #MCSample('ggZHToSSTodddd_tau300mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 24999),
+    #MCSample('ggZHToSSTodddd_tau1000mm_M55_20162', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM', 25000),
 ]
 
 all_bjet_signal_samples_20162 = mfv_signal_samples_20162 + mfv_stopdbardbar_samples_20162 + mfv_stopbbarbbar_samples_20162 + ggHToSSTodddd_samples_20162 + ttHToLLPs_bbbb_samples_20162 + ttHToLLPs_dddd_samples_20162
@@ -1686,9 +1686,9 @@ ggZHToSSTobbbb_samples_2017 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau10mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau30mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTobbbb_tau100mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTobbbb_tau300mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTobbbb_tau1000mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTobbbb_tau100mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTobbbb_tau300mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTobbbb_tau1000mm_M15_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
 
     MCSample('ggZHToSSTobbbb_tau0um_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau10um_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
@@ -1699,9 +1699,9 @@ ggZHToSSTobbbb_samples_2017 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau10mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau30mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTobbbb_tau100mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTobbbb_tau300mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTobbbb_tau1000mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTobbbb_tau100mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTobbbb_tau300mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTobbbb_tau1000mm_M40_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
 
     MCSample('ggZHToSSTobbbb_tau0um_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau10um_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49999),
@@ -1712,9 +1712,9 @@ ggZHToSSTobbbb_samples_2017 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau10mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49999),
     MCSample('ggZHToSSTobbbb_tau30mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49999),
-    MCSample('ggZHToSSTobbbb_tau100mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTobbbb_tau300mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 48999),
-    MCSample('ggZHToSSTobbbb_tau1000mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49000),
+    #MCSample('ggZHToSSTobbbb_tau100mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTobbbb_tau300mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 48999),
+    #MCSample('ggZHToSSTobbbb_tau1000mm_M55_2017', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49000),
 ]
 
 ggZHToSSTodddd_samples_2017 = [
@@ -1727,9 +1727,9 @@ ggZHToSSTodddd_samples_2017 = [
     MCSample('ggZHToSSTodddd_tau3mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTodddd_tau10mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTodddd_tau30mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTodddd_tau100mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTodddd_tau300mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49000),
-    MCSample('ggZHToSSTodddd_tau1000mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTodddd_tau100mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTodddd_tau300mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49000),
+    #MCSample('ggZHToSSTodddd_tau1000mm_M15_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
 
     MCSample('ggZHToSSTodddd_tau0um_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTodddd_tau10um_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
@@ -1740,9 +1740,9 @@ ggZHToSSTodddd_samples_2017 = [
     MCSample('ggZHToSSTodddd_tau3mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49000),
     MCSample('ggZHToSSTodddd_tau10mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTodddd_tau30mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTodddd_tau100mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTodddd_tau300mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTodddd_tau1000mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTodddd_tau100mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTodddd_tau300mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTodddd_tau1000mm_M40_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
 
     MCSample('ggZHToSSTodddd_tau0um_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 48998),
     MCSample('ggZHToSSTodddd_tau10um_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
@@ -1753,9 +1753,9 @@ ggZHToSSTodddd_samples_2017 = [
     MCSample('ggZHToSSTodddd_tau3mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49998),
     MCSample('ggZHToSSTodddd_tau10mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49998),
     MCSample('ggZHToSSTodddd_tau30mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49996),
-    MCSample('ggZHToSSTodddd_tau100mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTodddd_tau300mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49997),
-    MCSample('ggZHToSSTodddd_tau1000mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49999),
+    #MCSample('ggZHToSSTodddd_tau100mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTodddd_tau300mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49997),
+    #MCSample('ggZHToSSTodddd_tau1000mm_M55_2017', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL17MiniAODv2-106X_mc2017_realistic_v9-v2/MINIAODSIM', 49999),
 ]
 
 all_bjet_signal_samples_2017 = mfv_signal_samples_2017 + mfv_stopdbardbar_samples_2017 + mfv_stopbbarbbar_samples_2017 + ggHToSSTodddd_samples_2017 + ttHToLLPs_bbbb_samples_2017 + ttHToLLPs_dddd_samples_2017
@@ -2246,9 +2246,9 @@ ggZHToSSTobbbb_samples_2018 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau10mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau30mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTobbbb_tau100mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTobbbb_tau300mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTobbbb_tau1000mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTobbbb_tau100mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTobbbb_tau300mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTobbbb_tau1000mm_M15_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
 
     MCSample('ggZHToSSTobbbb_tau0um_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 48000),
     MCSample('ggZHToSSTobbbb_tau10um_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
@@ -2259,9 +2259,9 @@ ggZHToSSTobbbb_samples_2018 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau10mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau30mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 48000),
-    MCSample('ggZHToSSTobbbb_tau100mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTobbbb_tau300mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 48000),
-    MCSample('ggZHToSSTobbbb_tau1000mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTobbbb_tau100mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTobbbb_tau300mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 48000),
+    #MCSample('ggZHToSSTobbbb_tau1000mm_M40_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
 
     MCSample('ggZHToSSTobbbb_tau0um_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTobbbb_tau10um_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
@@ -2272,9 +2272,9 @@ ggZHToSSTobbbb_samples_2018 = [
     MCSample('ggZHToSSTobbbb_tau3mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 48998),
     MCSample('ggZHToSSTobbbb_tau10mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
     MCSample('ggZHToSSTobbbb_tau30mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
-    MCSample('ggZHToSSTobbbb_tau100mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49998),
-    MCSample('ggZHToSSTobbbb_tau300mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
-    MCSample('ggZHToSSTobbbb_tau1000mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTobbbb_tau100mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49998),
+    #MCSample('ggZHToSSTobbbb_tau300mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
+    #MCSample('ggZHToSSTobbbb_tau1000mm_M55_2018', '/ggZH_HToSSTobbbb_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
 ]
 
 ggZHToSSTodddd_samples_2018 = [
@@ -2287,9 +2287,9 @@ ggZHToSSTodddd_samples_2018 = [
     MCSample('ggZHToSSTodddd_tau3mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTodddd_tau10mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTodddd_tau30mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTodddd_tau100mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49000),
-    MCSample('ggZHToSSTodddd_tau300mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTodddd_tau1000mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTodddd_tau100mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49000),
+    #MCSample('ggZHToSSTodddd_tau300mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTodddd_tau1000mm_M15_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-15_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
 
     MCSample('ggZHToSSTodddd_tau0um_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
     MCSample('ggZHToSSTodddd_tau10um_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
@@ -2300,9 +2300,9 @@ ggZHToSSTodddd_samples_2018 = [
     MCSample('ggZHToSSTodddd_tau3mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49000),
     MCSample('ggZHToSSTodddd_tau10mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49000),
     MCSample('ggZHToSSTodddd_tau30mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
-    MCSample('ggZHToSSTodddd_tau100mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
-    MCSample('ggZHToSSTodddd_tau300mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49000),
-    MCSample('ggZHToSSTodddd_tau1000mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTodddd_tau100mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTodddd_tau300mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49000),
+    #MCSample('ggZHToSSTodddd_tau1000mm_M40_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-40_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
 
     MCSample('ggZHToSSTodddd_tau0um_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49998),
     MCSample('ggZHToSSTodddd_tau10um_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-0p01_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
@@ -2313,9 +2313,9 @@ ggZHToSSTodddd_samples_2018 = [
     MCSample('ggZHToSSTodddd_tau3mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-3_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
     MCSample('ggZHToSSTodddd_tau10mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-10_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49998),
     MCSample('ggZHToSSTodddd_tau30mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-30_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 48999),
-    MCSample('ggZHToSSTodddd_tau100mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
-    MCSample('ggZHToSSTodddd_tau300mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 47999),
-    MCSample('ggZHToSSTodddd_tau1000mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
+    #MCSample('ggZHToSSTodddd_tau100mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-100_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 49999),
+    #MCSample('ggZHToSSTodddd_tau300mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-300_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 47999),
+    #MCSample('ggZHToSSTodddd_tau1000mm_M55_2018', '/ggZH_HToSSTodddd_ZToLL_MH-125_MS-55_ctauS-1000_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM', 50000),
 ]
 
 all_bjet_signal_samples_2018 = mfv_signal_samples_2018 + mfv_stopdbardbar_samples_2018 + mfv_stopbbarbbar_samples_2018 + ggHToSSTodddd_samples_2018 + ttHToLLPs_bbbb_samples_2018 + ttHToLLPs_dddd_samples_2018


### PR DESCRIPTION
Added ggZH sample entries for every year in Samples.py
Updated cross-sections for ggZH and quark-initiated ZH to match yellow report relative contributions
Registered ggZH samples so they are Condorable